### PR TITLE
Fix Storage::FaultTolerantProxy open and reopen methods

### DIFF
--- a/lib/faulty/storage/fault_tolerant_proxy.rb
+++ b/lib/faulty/storage/fault_tolerant_proxy.rb
@@ -53,8 +53,8 @@ module Faulty
       # @see Interface#open
       # @param (see Interface#open)
       # @return (see Interface#open)
-      def open(circuit)
-        @storage.open(circuit)
+      def open(circuit, opened_at)
+        @storage.open(circuit, opened_at)
       rescue StandardError => e
         options.notifier.notify(:storage_failure, circuit: circuit, action: :open, error: e)
         false
@@ -65,8 +65,8 @@ module Faulty
       # @see Interface#reopen
       # @param (see Interface#reopen)
       # @return (see Interface#reopen)
-      def reopen(circuit)
-        @storage.reopen(circuit)
+      def reopen(circuit, opened_at, previous_opened_at)
+        @storage.reopen(circuit, opened_at, previous_opened_at)
       rescue StandardError => e
         options.notifier.notify(:storage_failure, circuit: circuit, action: :reopen, error: e)
         false

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -239,4 +239,17 @@ RSpec.context :circuits do
 
     it 'accepts a connection pool'
   end
+
+  context 'with fault-tolerant redis storage' do
+    let(:storage) do
+      Faulty::Storage::FaultTolerantProxy.new(
+        Faulty::Storage::Redis.new,
+        notifier: Faulty::Events::Notifier.new
+      )
+    end
+
+    after { circuit.reset! }
+
+    it_behaves_like 'circuit'
+  end
 end


### PR DESCRIPTION
They were using an old API with different arguments. Additionally,
expand the circuit spec to test FaultTolerantProxy so that API
incompatibilities will be detected.