### PR TITLE
Handle crashes for event listeners

### DIFF
--- a/lib/faulty/events/notifier.rb
+++ b/lib/faulty/events/notifier.rb
@@ -11,6 +11,9 @@ module Faulty
 
       # Notify all listeners of an event
       #
+      # If a listener raises an error while handling an event, that error will
+      # be captured and written to STDERR.
+      #
       # @param event [Symbol] The event name
       # @param payload [Hash] A hash of event payload data. The payload keys
       #   differ between events, but should be consistent across calls for a
@@ -18,7 +21,13 @@ module Faulty
       def notify(event, payload)
         raise ArgumentError, "Unknown event #{event}" unless EVENTS.include?(event)
 
-        @listeners.each { |l| l.handle(event, payload) }
+        @listeners.each do |listener|
+          begin
+            listener.handle(event, payload)
+          rescue StandardError => e
+            warn "Faulty listener #{listener.class.name} crashed: #{e.message}"
+          end
+        end
       end
     end
   end

--- a/spec/events/notifier_spec.rb
+++ b/spec/events/notifier_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Events::Notifier do
+  let(:listener_class) do
+    Class.new do
+      attr_reader :events
+
+      def initialize
+        @events = []
+      end
+
+      def handle(event, payload)
+        @events << [event, payload]
+      end
+    end
+  end
+
+  let(:failing_class) do
+    Class.new do
+      def self.name
+        'Failing'
+      end
+
+      def handle(_event, _payload)
+        raise 'fail'
+      end
+    end
+  end
+
+  it 'calls handle for each listener' do
+    listeners = [listener_class.new, listener_class.new]
+    notifier = described_class.new(listeners)
+    notifier.notify(:circuit_closed, {})
+    expect(listeners[0].events).to eq([[:circuit_closed, {}]])
+    expect(listeners[1].events).to eq([[:circuit_closed, {}]])
+  end
+
+  it 'suppresses and prints errors' do
+    notifier = described_class.new([failing_class.new])
+    expect { notifier.notify(:circuit_opened, {}) }
+      .to output("Faulty listener Failing crashed: fail\n").to_stderr
+  end
+
+  it 'raises error for incorrect event' do
+    notifier = described_class.new
+    expect { notifier.notify(:foo, {}) }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
If a listener crashes, we capture and output the error. This ensures
that Faulty can continue to operate even if a listener starts failing.