### PR TITLE
Fix bug where memory storage would delete the newest entries

### DIFF
--- a/lib/faulty/storage/memory.rb
+++ b/lib/faulty/storage/memory.rb
@@ -83,7 +83,7 @@ module Faulty
         memory = fetch(circuit)
         memory.runs.borrow do |runs|
           runs.push([time, success])
-          runs.pop if runs.size > options.max_sample_size
+          runs.shift if runs.size > options.max_sample_size
         end
         memory.status(circuit.options)
       end

--- a/spec/storage/memory_spec.rb
+++ b/spec/storage/memory_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Storage::Memory do
+  let(:circuit) { Faulty::Circuit.new('test') }
+
+  it 'rotates entries after max_sample_size' do
+    storage = described_class.new(max_sample_size: 3)
+    3.times { |i| storage.entry(circuit, i, true) }
+    expect(storage.history(circuit).map { |h| h[0] }).to eq([0, 1, 2])
+    storage.entry(circuit, 9, true)
+    expect(storage.history(circuit).map { |h| h[0] }).to eq([1, 2, 9])
+  end
+end


### PR DESCRIPTION
Instead of clearing the oldest entries, Faulty::Storage::Memory would
clear the newest entries once it became full. Fix this and add a spec
for it.