### PR TITLE
Fix redis bug where concurrent CAS requests could crash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Layout/LineLength:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Layout/RescueEnsureAlignment:
+  Enabled: false
+
 Lint/RaiseException:
   Enabled: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - jruby
+  - truffleruby
 
 env:
   global:
@@ -22,8 +24,8 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - bin/rubocop
-  - bin/rspec --format doc
+  - bundle exec rubocop
+  - bundle exec rspec --format doc
   - bin/check-version
 
 after_script:

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,20 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# We add non-essential gems like debugging tools and CI dependencies
+# here. This also allows us to use conditional dependencies that depend on the
+# platform
+
+not_jruby = %i[ruby mingw x64_mingw].freeze
+
+gem 'activesupport', '>= 4.2'
+gem 'bundler', '>= 1.17', '< 3'
+gem 'byebug', platforms: not_jruby
+gem 'irb', '~> 1.0'
+gem 'redcarpet', '~> 3.5', platforms: not_jruby
+gem 'rspec_junit_formatter', '~> 0.4'
+# For now, code climate doesn't support simplecov 0.18
+# https://github.com/codeclimate/test-reporter/issues/413
+gem 'simplecov', '>= 0.17.1', '< 0.18'
+gem 'yard', '~> 0.9.25', platforms: not_jruby

--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 
 require 'bundler/setup'
 require 'faulty'
-require 'byebug'
+require 'byebug' if Gem.loaded_specs['byebug']
 require 'irb'
 
 # For default cache support

--- a/faulty.gemspec
+++ b/faulty.gemspec
@@ -23,22 +23,14 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
-  spec.add_development_dependency 'activesupport', '>= 4.2'
-  spec.add_development_dependency 'bundler', '>= 1.17', '< 3'
-  spec.add_development_dependency 'byebug', '~> 11.0'
+  # Only essential development tools and dependencies go here.
+  # Other non-essential development dependencies go in the Gemfile.
   spec.add_development_dependency 'connection_pool', '~> 2.0'
   spec.add_development_dependency 'honeybadger', '>= 2.0'
-  spec.add_development_dependency 'irb', '~> 1.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'redis', '~> 3.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
   # 0.81 is the last rubocop version with Ruby 2.3 support
   spec.add_development_dependency 'rubocop', '0.81.0'
   spec.add_development_dependency 'rubocop-rspec', '1.38.1'
-  # For now, code climate doesn't support simplecov 0.18
-  # https://github.com/codeclimate/test-reporter/issues/413
-  spec.add_development_dependency 'simplecov', '>= 0.17.1', '< 0.18'
   spec.add_development_dependency 'timecop', '>= 0.9'
-  spec.add_development_dependency 'yard', '~> 0.9.25'
 end

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -288,15 +288,15 @@ module Faulty
       # @return [Boolean] True if the value was set to `new`, false if the CAS
       #   failed
       def compare_and_set(redis, key, old, new)
-        result = redis.watch(key) do
+        redis.watch(key) do
           if old.include?(redis.get(key))
-            redis.multi { |m| m.set(key, new) }
+            result = redis.multi { |m| m.set(key, new) }
+            result && result[0] == 'OK'
           else
             redis.unwatch
+            false
           end
         end
-
-        result[0] == 'OK'
       end
 
       # Yield a Redis connection

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'byebug'
+require 'byebug' if Gem.loaded_specs['byebug']
 
 if ENV['COVERAGE']
   require 'simplecov'
@@ -15,6 +15,8 @@ end
 
 require 'faulty'
 require 'timecop'
+
+require_relative 'support/concurrency'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -31,4 +33,6 @@ RSpec.configure do |config|
   config.after do
     Timecop.return
   end
+
+  config.include Faulty::Specs::Concurrency
 end

--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -3,12 +3,45 @@
 require 'connection_pool'
 
 RSpec.describe Faulty::Storage::Redis do
-  let(:circuit) { Faulty::Circuit.new('test') }
+  subject(:storage) { described_class.new(**options.merge(client: client)) }
 
-  it 'accepts a connection pool' do
-    pool = ConnectionPool.new(size: 2, timeout: 1) { Redis.new(timeout: 1) }
-    storage = described_class.new(client: pool)
-    storage.entry(circuit, Faulty.current_time, true)
-    expect(storage.history(circuit).size).to eq(1)
+  let(:options) { {} }
+  let(:client) { Redis.new }
+  let(:circuit) { Faulty::Circuit.new('test', storage: storage) }
+
+  after { circuit.reset! }
+
+  context 'with default options' do
+    subject(:storage) { described_class.new }
+
+    it 'can add an entry' do
+      storage.entry(circuit, Faulty.current_time, true)
+      expect(storage.history(circuit).size).to eq(1)
+    end
+  end
+
+  context 'with connection pool' do
+    let(:pool_size) { 100 }
+
+    let(:client) do
+      ConnectionPool.new(size: pool_size, timeout: 1) { Redis.new(timeout: 1) }
+    end
+
+    it 'adds an entry' do
+      storage.entry(circuit, Faulty.current_time, true)
+      expect(storage.history(circuit).size).to eq(1)
+    end
+
+    it 'opens the circuit once when called concurrently', concurrency: true do
+      concurrent_warmup do
+        # Do something small just to get a connection from the pool
+        storage.unlock(circuit)
+      end
+
+      result = concurrently(pool_size) do
+        storage.open(circuit, Faulty.current_time)
+      end
+      expect(result.count { |r| r }).to eq(1)
+    end
   end
 end

--- a/spec/support/concurrency.rb
+++ b/spec/support/concurrency.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Faulty
+  module Specs
+    module Concurrency
+      def concurrent_warmup(&block)
+        @concurrent_warmup = block
+      end
+
+      def concurrently(times = 100, timeout: 3)
+        barrier = Concurrent::CyclicBarrier.new(times)
+
+        execute = lambda do
+          @concurrent_warmup&.call
+          barrier.wait(timeout)
+          error = nil
+          result = begin
+            yield
+          rescue StandardError => e
+            error = e
+          end
+
+          barrier.wait(timeout)
+          raise error if error
+
+          result
+        end
+
+        threads = (0...(times - 1)).map do
+          Thread.new do
+            Thread.current.report_on_exception = false if Thread.current.respond_to?(:report_on_exception=)
+            execute.call
+          end
+        end
+        main_result = execute.call
+        threads.map(&:value) + [main_result]
+      end
+    end
+  end
+end


### PR DESCRIPTION
The bug happened when multiple clients opened or closed a circuit
concurrently, exposing a bug with the CAS implementation. Fix this bug,
and also add concurrency tests to expose the issue.

Also add support for jruby and truffleruby. This allows us to test
concurrency with real paralllel threads. To add jruby support to specs,
we need to move non-essential gems to the Gemfile instead of the gemspec since
some aren't compatible with jruby.