### PR TITLE
Fix redis storage to expire state key when using CAS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 30
 
+Naming/MethodParameterName:
+  MinNameLength: 1
+
 Style/Documentation:
   Enabled: false
 

--- a/lib/faulty/result.rb
+++ b/lib/faulty/result.rb
@@ -53,7 +53,7 @@ module Faulty
     #
     # @param ok An ok value
     # @param error [Error] An error instance
-    def initialize(ok: NOTHING, error: NOTHING) # rubocop:disable Naming/MethodParameterName
+    def initialize(ok: NOTHING, error: NOTHING)
       if ok.equal?(NOTHING) && error.equal?(NOTHING)
         raise ArgumentError, 'Result must have an ok or error value'
       end


### PR DESCRIPTION
When using compare_and_set, Redis storage would not set an expiration
for the state key. This means that key could be stored indefinitely.
Fix compare_and_set to always set an expiration.