### PR TITLE
Add tools for backend fault-tolerance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,9 @@ RSpec/FilePath:
 RSpec/NamedSubject:
   Enabled: false
 
+RSpec/MessageSpies:
+  Enabled: false
+
 RSpec/MultipleExpectations:
   Enabled: false
 

--- a/lib/faulty/cache.rb
+++ b/lib/faulty/cache.rb
@@ -6,7 +6,9 @@ class Faulty
   end
 end
 
+require 'faulty/cache/auto_wire'
 require 'faulty/cache/default'
+require 'faulty/cache/circuit_proxy'
 require 'faulty/cache/fault_tolerant_proxy'
 require 'faulty/cache/mock'
 require 'faulty/cache/null'

--- a/lib/faulty/cache/auto_wire.rb
+++ b/lib/faulty/cache/auto_wire.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Cache
+    # Automatically configure a cache backend
+    #
+    # Used by {Faulty#initialize} to setup sensible cache defaults
+    class AutoWire
+      extend Forwardable
+
+      # Options for {AutoWire}
+      Options = Struct.new(
+        :notifier
+      ) do
+        include ImmutableOptions
+
+        private
+
+        def required
+          %i[notifier]
+        end
+      end
+
+      # Wrap a cache backend with sensible defaults
+      #
+      # If the cache is `nil`, create a new {Default}.
+      #
+      # If the backend is not fault tolerant, wrap it in {CircuitProxy} and
+      # {FaultTolerantProxy}.
+      #
+      # @param cache [Interface] A cache backend
+      # @param options [Hash] Attributes for {Options}
+      # @yield [Options] For setting options in a block
+      def initialize(cache, **options, &block)
+        @options = Options.new(options, &block)
+        @cache = if cache.nil?
+          Cache::Default.new
+        elsif cache.fault_tolerant?
+          cache
+        else
+          Cache::FaultTolerantProxy.new(
+            Cache::CircuitProxy.new(cache, notifier: @options.notifier),
+            notifier: @options.notifier
+          )
+        end
+
+        freeze
+      end
+
+      # @!method read(key)
+      #   (see Faulty::Cache::Interface#read)
+      #
+      # @!method write(key, value, expires_in: expires_in)
+      #   (see Faulty::Cache::Interface#write)
+      def_delegators :@cache, :read, :write
+
+      # Auto-wired caches are always fault tolerant
+      #
+      # @return [true]
+      def fault_tolerant?
+        true
+      end
+    end
+  end
+end

--- a/lib/faulty/cache/circuit_proxy.rb
+++ b/lib/faulty/cache/circuit_proxy.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Cache
+    # A circuit wrapper for cache backends
+    #
+    # This class uses an internal {Circuit} to prevent the cache backend from
+    # causing application issues. If the backend fails continuously, this
+    # circuit will trip to prevent cascading failures. This internal circuit
+    # uses an independent in-memory backend by default.
+    class CircuitProxy
+      attr_reader :options
+
+      # Options for {CircuitProxy}
+      #
+      # @!attribute [r] circuit
+      #   @return [Circuit] A replacement for the internal circuit. When
+      #     modifying this, be careful to use only a reliable circuit storage
+      #     backend so that you don't introduce cascading failures.
+      # @!attribute [r] notifier
+      #   @return [Events::Notifier] A Faulty notifier to use for failure
+      #     notifications. If `circuit` is given, this is ignored.
+      Options = Struct.new(
+        :circuit,
+        :notifier
+      ) do
+        include ImmutableOptions
+
+        private
+
+        def finalize
+          raise ArgumentError, 'The circuit or notifier option must be given' unless notifier || circuit
+
+          self.circuit ||= Circuit.new(
+            Faulty::Storage::CircuitProxy.name,
+            notifier: notifier,
+            cache: Cache::Null.new
+          )
+        end
+      end
+
+      # @param cache [Cache::Interface] The cache backend to wrap
+      # @param options [Hash] Attributes for {Options}
+      # @yield [Options] For setting options in a block
+      def initialize(cache, **options, &block)
+        @cache = cache
+        @options = Options.new(options, &block)
+      end
+
+      %i[read write].each do |method|
+        define_method(method) do |*args|
+          options.circuit.run { @cache.public_send(method, *args) }
+        end
+      end
+
+      def fault_tolerant?
+        @cache.fault_tolerant?
+      end
+    end
+  end
+end

--- a/lib/faulty/cache/default.rb
+++ b/lib/faulty/cache/default.rb
@@ -11,6 +11,8 @@ class Faulty
     # - If ActiveSupport is available, it will use an `ActiveSupport::Cache::MemoryStore`
     # - Otherwise it will use a {Faulty::Cache::Null}
     class Default
+      extend Forwardable
+
       def initialize
         @cache = if defined?(::Rails)
           Cache::Rails.new(::Rails.cache)
@@ -21,28 +23,15 @@ class Faulty
         end
       end
 
-      # Read from the internal cache by key
+      # @!method read(key)
+      #   (see Faulty::Cache::Interface#read)
       #
-      # @param (see Cache::Interface#read)
-      # @return (see Cache::Interface#read)
-      def read(key)
-        @cache.read(key)
-      end
-
-      # Write to the internal cache
+      # @!method write(key, value, expires_in: expires_in)
+      #   (see Faulty::Cache::Interface#write)
       #
-      # @param (see Cache::Interface#read)
-      # @return (see Cache::Interface#read)
-      def write(key, value, expires_in: nil)
-        @cache.write(key, value, expires_in: expires_in)
-      end
-
-      # This cache is fault tolerant if the internal one is
-      #
-      # @return [Boolean]
-      def fault_tolerant?
-        @cache.fault_tolerant?
-      end
+      # @!method fault_tolerant
+      #   (see Faulty::Cache::Interface#fault_tolerant?)
+      def_delegators :@cache, :read, :write, :fault_tolerant?
     end
   end
 end

--- a/lib/faulty/cache/rails.rb
+++ b/lib/faulty/cache/rails.rb
@@ -5,6 +5,8 @@ class Faulty
     # A wrapper for a Rails or ActiveSupport cache
     #
     class Rails
+      extend Forwardable
+
       # @param cache The Rails cache to wrap
       # @param fault_tolerant [Boolean] Whether the Rails cache is
       #   fault_tolerant. See {#fault_tolerant?} for more details
@@ -13,15 +15,12 @@ class Faulty
         @fault_tolerant = fault_tolerant
       end
 
-      # (see Interface#read)
-      def read(key)
-        @cache.read(key)
-      end
-
-      # (see Interface#read)
-      def write(key, value, expires_in: nil)
-        @cache.write(key, value, expires_in: expires_in)
-      end
+      # @!method read(key)
+      #   (see Faulty::Cache::Interface#read)
+      #
+      # @!method write(key, value, expires_in: expires_in)
+      #   (see Faulty::Cache::Interface#write)
+      def_delegators :@cache, :read, :write
 
       # Although ActiveSupport cache implementations are fault-tolerant,
       # Rails.cache is not guranteed to be fault tolerant. For this reason,

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -66,14 +66,19 @@ class Faulty
     #   @return [Error, Array<Error>] An array of errors that are considered circuit
     #     failures. Default `[StandardError]`.
     # @!attribute [r] exclude
-    #   @return [Error, Array<Error>] An array of errors that will be captured and
-    #     considered circuit failures. Default `[]`.
+    #   @return [Error, Array<Error>] An array of errors that will not be
+    #     captured by Faulty. These errors will not be considered circuit
+    #     failures. Default `[]`.
     # @!attribute [r] cache
-    #   @return [Cache::Interface] The cache backend. Default `Cache::Null.new`
+    #   @return [Cache::Interface] The cache backend. Default
+    #   `Cache::Null.new`. Unlike {Faulty#initialize}, this is not wrapped in
+    #   {Cache::AutoWire} by default.
     # @!attribute [r] notifier
     #   @return [Events::Notifier] A Faulty notifier. Default `Events::Notifier.new`
     # @!attribute [r] storage
-    #   @return [Storage::Interface] The storage backend. Default `Storage::Memory.new`
+    #   @return [Storage::Interface] The storage backend. Default
+    #   `Storage::Memory.new`. Unlike {Faulty#initialize}, this is not wrapped
+    #    in {Storage::AutoWire} by default.
     Options = Struct.new(
       :cache_expires_in,
       :cache_refreshes_after,

--- a/lib/faulty/error.rb
+++ b/lib/faulty/error.rb
@@ -59,8 +59,22 @@ class Faulty
   # Raised if calling get or error on a result without checking it
   class UncheckedResultError < FaultyError; end
 
+  # An error that wraps multiple other errors
+  class FaultyMultiError < FaultyError
+    def initialize(message, errors)
+      message = "#{message}: #{errors.map(&:message).join(', ')}"
+      super(message)
+    end
+  end
+
   # Raised if getting the wrong result type.
   #
   # For example, calling get on an error result will raise this
   class WrongResultError < FaultyError; end
+
+  # Raised if a FallbackChain partially fails
+  class PartialFailureError < FaultyMultiError; end
+
+  # Raised if all FallbackChain backends fail
+  class AllFailedError < FaultyMultiError; end
 end

--- a/lib/faulty/storage.rb
+++ b/lib/faulty/storage.rb
@@ -6,6 +6,9 @@ class Faulty
   end
 end
 
+require 'faulty/storage/auto_wire'
+require 'faulty/storage/circuit_proxy'
+require 'faulty/storage/fallback_chain'
 require 'faulty/storage/fault_tolerant_proxy'
 require 'faulty/storage/memory'
 require 'faulty/storage/redis'

--- a/lib/faulty/storage/auto_wire.rb
+++ b/lib/faulty/storage/auto_wire.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Storage
+    # Automatically configure a storage backend
+    #
+    # Used by {Faulty#initialize} to setup sensible storage defaults
+    class AutoWire
+      extend Forwardable
+
+      # Options for {AutoWire}
+      Options = Struct.new(
+        :notifier
+      ) do
+        include ImmutableOptions
+
+        private
+
+        def required
+          %i[notifier]
+        end
+      end
+
+      # Wrap storage backends with sensible defaults
+      #
+      # If the cache is `nil`, create a new {Memory} storage.
+      #
+      # If a single storage backend is given and is fault tolerant, leave it
+      # unmodified.
+      #
+      # If a single storage backend is given and is not fault tolerant, wrap it
+      # in a {CircuitProxy} and a {FaultTolerantProxy}.
+      #
+      # If an array of storage backends is given, wrap each non-fault-tolerant
+      # entry in a {CircuitProxy} and create a {FallbackChain}. If none of the
+      # backends in the array are fault tolerant, also wrap the {FallbackChain}
+      # in a {FaultTolerantProxy}.
+      #
+      # @todo Consider using a {FallbackChain} for non-fault-tolerant storages
+      #   by default. This would fallback to a {Memory} storage. It would
+      #   require a more conservative implementation of {Memory} that could
+      #   limit the number of circuits stored. For now, users need to manually
+      #   configure fallbacks.
+      #
+      # @param storage [Interface, Array<Interface>] A storage backed or array
+      #   of storage backends to setup.
+      # @param options [Hash] Attributes for {Options}
+      # @yield [Options] For setting options in a block
+      def initialize(storage, **options, &block)
+        @options = Options.new(options, &block)
+        @storage = if storage.nil?
+          Memory.new
+        elsif storage.is_a?(Array)
+          wrap_array(storage)
+        elsif !storage.fault_tolerant?
+          wrap_one(storage)
+        else
+          storage
+        end
+
+        freeze
+      end
+
+      # @!method entry(circuit, time, success)
+      #   (see Faulty::Storage::Interface#entry)
+      #
+      # @!method open(circuit, opened_at)
+      #   (see Faulty::Storage::Interface#open)
+      #
+      # @!method reopen(circuit, opened_at, previous_opened_at)
+      #   (see Faulty::Storage::Interface#reopen)
+      #
+      # @!method close(circuit)
+      #   (see Faulty::Storage::Interface#close)
+      #
+      # @!method lock(circuit, state)
+      #   (see Faulty::Storage::Interface#lock)
+      #
+      # @!method unlock(circuit)
+      #   (see Faulty::Storage::Interface#unlock)
+      #
+      # @!method reset(circuit)
+      #   (see Faulty::Storage::Interface#reset)
+      #
+      # @!method status(circuit)
+      #   (see Faulty::Storage::Interface#status)
+      #
+      # @!method history(circuit)
+      #   (see Faulty::Storage::Interface#history)
+      #
+      # @!method list
+      #   (see Faulty::Storage::Interface#list)
+      #
+      def_delegators :@storage,
+        :entry, :open, :reopen, :close, :lock,
+        :unlock, :reset, :status, :history, :list
+
+      def fault_tolerant?
+        true
+      end
+
+      private
+
+      # Wrap an array of storage backends in a fault-tolerant FallbackChain
+      #
+      # @return [Storage::Interface] A fault-tolerant fallback chain
+      def wrap_array(array)
+        FaultTolerantProxy.wrap(FallbackChain.new(
+          array.map { |s| s.fault_tolerant? ? s : CircuitProxy.new(s, notifier: @options.notifier) },
+          notifier: @options.notifier
+        ), notifier: @options.notifier)
+      end
+
+      def wrap_one(storage)
+        FaultTolerantProxy.new(
+          CircuitProxy.new(storage, notifier: @options.notifier),
+          notifier: @options.notifier
+        )
+      end
+    end
+  end
+end

--- a/lib/faulty/storage/circuit_proxy.rb
+++ b/lib/faulty/storage/circuit_proxy.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Storage
+    # A circuit wrapper for storage backends
+    #
+    # This class uses an internal {Circuit} to prevent the storage backend from
+    # causing application issues. If the backend fails continuously, this
+    # circuit will trip to prevent cascading failures. This internal circuit
+    # uses an independent in-memory backend by default.
+    class CircuitProxy
+      attr_reader :options
+
+      # Options for {CircuitProxy}
+      #
+      # @!attribute [r] circuit
+      #   @return [Circuit] A replacement for the internal circuit. When
+      #     modifying this, be careful to use only a reliable storage backend
+      #     so that you don't introduce cascading failures.
+      # @!attribute [r] notifier
+      #   @return [Events::Notifier] A Faulty notifier to use for circuit
+      #     notifications. If `circuit` is given, this is ignored.
+      Options = Struct.new(
+        :circuit,
+        :notifier
+      ) do
+        include ImmutableOptions
+
+        private
+
+        def finalize
+          raise ArgumentError, 'The circuit or notifier option must be given' unless notifier || circuit
+
+          self.circuit ||= Circuit.new(
+            Faulty::Storage::CircuitProxy.name,
+            notifier: notifier,
+            cache: Cache::Null.new
+          )
+        end
+      end
+
+      # @param storage [Storage::Interface] The storage backend to wrap
+      # @param options [Hash] Attributes for {Options}
+      # @yield [Options] For setting options in a block
+      def initialize(storage, **options, &block)
+        @storage = storage
+        @options = Options.new(options, &block)
+      end
+
+      %i[entry open reopen close lock unlock reset status history list].each do |method|
+        define_method(method) do |*args|
+          options.circuit.run { @storage.public_send(method, *args) }
+        end
+      end
+
+      # This cache makes any storage fault tolerant, so this is always `true`
+      #
+      # @return [true]
+      def fault_tolerant?
+        @storage.fault_tolerant?
+      end
+    end
+  end
+end

--- a/lib/faulty/storage/fallback_chain.rb
+++ b/lib/faulty/storage/fallback_chain.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Storage
+    # An prioritized list of storage backends
+    #
+    # If any backend fails, the next will be tried until one succeeds. This
+    # should typically be used when using a fault-prone backend such as
+    # {Storage::Redis}.
+    #
+    # This is used by {Faulty#initialize} if the `storage` option is set to an
+    # array.
+    #
+    # @example
+    #   # This storage will try Redis first, then fallback to memory storage
+    #   # if Redis is unavailable.
+    #   storage = Faulty::Storage::FallbackChain.new([
+    #     Faulty::Storage::Redis.new,
+    #     Faulty::Storage::Memory.new
+    #   ])
+    class FallbackChain
+      attr_reader :options
+
+      # Options for {FallbackChain}
+      #
+      # @!attribute [r] notifier
+      #   @return [Events::Notifier] A Faulty notifier
+      Options = Struct.new(
+        :notifier
+      ) do
+        include ImmutableOptions
+
+        private
+
+        def required
+          %i[notifier]
+        end
+      end
+
+      # Create a new {FallbackChain} to automatically fallback to reliable storage
+      #
+      # @param storages [Array<Storage::Interface>] An array of storage backends.
+      #   The primary storage should be specified first. If that one fails,
+      #   additional entries will be tried in sequence until one succeeds.
+      # @param options [Hash] Attributes for {Options}
+      # @yield [Options] For setting options in a block
+      def initialize(storages, **options, &block)
+        @storages = storages
+        @options = Options.new(options, &block)
+      end
+
+      # Create a circuit entry in the first available storage backend
+      #
+      # @param (see Interface#entry)
+      # @return (see Interface#entry)
+      def entry(circuit, time, success)
+        send_chain(:entry, circuit, time, success) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :entry, error: e)
+        end
+      end
+
+      # Open a circuit in the first available storage backend
+      #
+      # @param (see Interface#open)
+      # @return (see Interface#open)
+      def open(circuit, opened_at)
+        send_chain(:open, circuit, opened_at) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :open, error: e)
+        end
+      end
+
+      # Reopen a circuit in the first available storage backend
+      #
+      # @param (see Interface#reopen)
+      # @return (see Interface#reopen)
+      def reopen(circuit, opened_at, previous_opened_at)
+        send_chain(:reopen, circuit, opened_at, previous_opened_at) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :reopen, error: e)
+        end
+      end
+
+      # Close a circuit in the first available storage backend
+      #
+      # @param (see Interface#close)
+      # @return (see Interface#close)
+      def close(circuit)
+        send_chain(:close, circuit) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :close, error: e)
+        end
+      end
+
+      # Lock a circuit in all storage backends
+      #
+      # @param (see Interface#lock)
+      # @return (see Interface#lock)
+      def lock(circuit, state)
+        send_all(:lock, circuit, state)
+      end
+
+      # Unlock a circuit in all storage backends
+      #
+      # @param (see Interface#unlock)
+      # @return (see Interface#unlock)
+      def unlock(circuit)
+        send_all(:unlock, circuit)
+      end
+
+      # Reset a circuit in all storage backends
+      #
+      # @param (see Interface#reset)
+      # @return (see Interface#reset)
+      def reset(circuit)
+        send_all(:reset, circuit)
+      end
+
+      # Get the status of a circuit from the first available storage backend
+      #
+      # @param (see Interface#status)
+      # @return (see Interface#status)
+      def status(circuit)
+        send_chain(:status, circuit) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :status, error: e)
+        end
+      end
+
+      # Get the history of a circuit from the first available storage backend
+      #
+      # @param (see Interface#history)
+      # @return (see Interface#history)
+      def history(circuit)
+        send_chain(:history, circuit) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :history, error: e)
+        end
+      end
+
+      # Get the list of circuits from the first available storage backend
+      #
+      # @param (see Interface#list)
+      # @return (see Interface#list)
+      def list
+        send_chain(:list) do |e|
+          options.notifier.notify(:storage_failure, action: :list, error: e)
+        end
+      end
+
+      # This is fault tolerant if any of the available backends are fault tolerant
+      #
+      # @param (see Interface#fault_tolerant?)
+      # @return (see Interface#fault_tolerant?)
+      def fault_tolerant?
+        @storages.any?(&:fault_tolerant?)
+      end
+
+      private
+
+      # Call a method on the backend and return the first successful result
+      #
+      # Short-circuits, so that if a call succeeds, no additional backends are
+      # called.
+      #
+      # @param method [Symbol] The method to call
+      # @param args [Array] The arguments to send
+      # @raise [AllFailedError] AllFailedError if all backends fail
+      # @return The return value from the first successful call
+      def send_chain(method, *args)
+        errors = []
+        @storages.each do |s|
+          begin
+            return s.public_send(method, *args)
+          rescue StandardError => e
+            errors << e
+            yield e
+          end
+        end
+
+        raise AllFailedError.new("#{self.class}##{method} failed for all storage backends", errors)
+      end
+
+      # Call a method on every backend
+      #
+      # @param method [Symbol] The method to call
+      # @param args [Array] The arguments to send
+      # @raise [AllFailedError] AllFailedError if all backends fail
+      # @raise [PartialFailureError] PartialFailureError if some but not all
+      #   backends fail
+      # @return [nil]
+      def send_all(method, *args)
+        errors = []
+        @storages.each do |s|
+          begin
+            s.public_send(method, *args)
+          rescue StandardError => e
+            errors << e
+          end
+        end
+
+        if errors.empty?
+          nil
+        elsif errors.size < @storages.size
+          raise PartialFailureError.new("#{self.class}##{method} failed for some storage backends", errors)
+        else
+          raise AllFailedError.new("#{self.class}##{method} failed for all storage backends", errors)
+        end
+      end
+    end
+  end
+end

--- a/lib/faulty/storage/memory.rb
+++ b/lib/faulty/storage/memory.rb
@@ -4,8 +4,9 @@ class Faulty
   module Storage
     # The default in-memory storage for circuits
     #
-    # This implementation is most suitable to single-process, low volume
-    # usage. It is thread-safe and circuit state is shared across threads.
+    # This implementation is thread-safe and circuit state is shared across
+    # threads. Since state is stored in-memory, this state is not shared across
+    # processes, or persisted across application restarts.
     #
     # Circuit state and runs are stored in memory. Although runs have a maximum
     # size within a circuit, there is no limit on the number of circuits that
@@ -18,6 +19,9 @@ class Faulty
     #
     # This can be used as a reference implementation for storage backends that
     # store a list of circuit run entries.
+    #
+    # @todo Add a more sophsticated implmentation that can limit the number of
+    #   circuits stored.
     class Memory
       attr_reader :options
 

--- a/spec/cache/auto_wire_spec.rb
+++ b/spec/cache/auto_wire_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Cache::AutoWire do
+  subject(:auto_wire) { described_class.new(backend, notifier: notifier) }
+
+  let(:notifier) { Faulty::Events::Notifier.new }
+  let(:backend) { nil }
+
+  # Typically it's a bad idea to test private interfaces, but in this case
+  # we're specifically interested in testing the implementation. The alternative
+  # would be to re-test functionality of each internal cache, and that seems
+  # like a worse alternative.
+  let(:internal) { auto_wire.instance_variable_get(:@cache) }
+
+  context 'with nil backend' do
+    it 'creates a new Default' do
+      expect(internal).to be_a(Faulty::Cache::Default)
+    end
+
+    shared_examples 'delegator to internal' do
+      it do
+        marker = Object.new
+        expect(internal).to receive(action).with(*args).and_return(marker)
+        expect(auto_wire.public_send(action, *args)).to eq(marker)
+      end
+    end
+
+    describe '#read' do
+      let(:action) { :read }
+      let(:args) { ['foo'] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#write' do
+      let(:action) { :write }
+      let(:args) { %w[foo val] }
+
+      it_behaves_like 'delegator to internal'
+    end
+  end
+
+  context 'with a fault-tolerant backend' do
+    let(:backend) { Faulty::Cache::Mock.new }
+
+    it 'delegates directly if a fault-tolerant backend is given' do
+      expect(internal).to eq(backend)
+    end
+  end
+
+  context 'with a non-fault-tolerant backend' do
+    let(:backend) { Faulty::Cache::Rails.new(nil, fault_tolerant: false) }
+
+    it 'is fault tolerant' do
+      expect(auto_wire).to be_fault_tolerant
+    end
+
+    it 'wraps in FaultTolerantProxy and CircuitProxy' do
+      expect(internal).to be_a(Faulty::Cache::FaultTolerantProxy)
+
+      circuit_proxy = internal.instance_variable_get(:@cache)
+      expect(circuit_proxy).to be_a(Faulty::Cache::CircuitProxy)
+
+      original = circuit_proxy.instance_variable_get(:@cache)
+      expect(original).to eq(backend)
+    end
+  end
+end

--- a/spec/cache/circuit_proxy_spec.rb
+++ b/spec/cache/circuit_proxy_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Cache::CircuitProxy do
+  let(:notifier) { Faulty::Events::Notifier.new }
+  let(:circuit) { Faulty::Circuit.new('test', sample_threshold: 2) }
+
+  let(:failing_cache) do
+    Class.new do
+      def method_missing(*_args) # rubocop:disable Style/MethodMissingSuper
+        raise 'fail'
+      end
+
+      def respond_to_missing?(*_args)
+        true
+      end
+    end
+  end
+
+  it 'trips its internal circuit when storage fails repeatedly' do
+    backend = failing_cache.new
+    proxy = described_class.new(backend, notifier: notifier, circuit: circuit)
+    begin
+      2.times { proxy.read('foo') }
+    rescue Faulty::CircuitFailureError
+      nil
+    end
+
+    expect { proxy.read('foo') }.to raise_error(Faulty::CircuitTrippedError)
+  end
+
+  it 'delegates fault_tolerant? directly' do
+    backend = instance_double(Faulty::Cache::Mock)
+    marker = Object.new
+    expect(backend).to receive(:fault_tolerant?).and_return(marker)
+    expect(described_class.new(backend, notifier: notifier).fault_tolerant?).to eq(marker)
+  end
+end

--- a/spec/faulty_spec.rb
+++ b/spec/faulty_spec.rb
@@ -101,25 +101,13 @@ RSpec.describe Faulty do
     expect(instance.list_circuits).to match_array(%w[test1 test2])
   end
 
-  it 'does not wrap fault-tolerant storage' do
-    storage = Faulty::Storage::Memory.new
-    instance = described_class.new(storage: storage)
-    expect(instance.options.storage).to equal(storage)
-  end
-
-  it 'does not wrap fault-tolerant cache' do
-    cache = Faulty::Cache::Null.new
-    instance = described_class.new(cache: cache)
-    expect(instance.options.cache).to equal(cache)
-  end
-
-  it 'wraps non-fault-tolerant storage in FaultTolerantProxy' do
+  it 'wraps non-fault-tolerant storage in AutoWire' do
     instance = described_class.new(storage: Faulty::Storage::Redis.new)
-    expect(instance.options.storage).to be_a(Faulty::Storage::FaultTolerantProxy)
+    expect(instance.options.storage).to be_a(Faulty::Storage::AutoWire)
   end
 
-  it 'wraps non-fault-tolerant cache in FaultTolerantProxy' do
+  it 'wraps non-fault-tolerant cache in AutoWire' do
     instance = described_class.new(cache: Faulty::Cache::Rails.new(nil))
-    expect(instance.options.cache).to be_a(Faulty::Cache::FaultTolerantProxy)
+    expect(instance.options.cache).to be_a(Faulty::Cache::AutoWire)
   end
 end

--- a/spec/storage/auto_wire_spec.rb
+++ b/spec/storage/auto_wire_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Storage::AutoWire do
+  subject(:auto_wire) { described_class.new(backend, notifier: notifier) }
+
+  let(:notifier) { Faulty::Events::Notifier.new }
+  let(:backend) { nil }
+
+  # Typically it's a bad idea to test private interfaces, but in this case
+  # we're specifically interested in testing the implementation. The alternative
+  # would be to re-test functionality of each internal storage, and that seems
+  # like a worse alternative.
+  let(:internal) { auto_wire.instance_variable_get(:@storage) }
+
+  context 'with nil backend' do
+    it 'creates a new Memory' do
+      expect(internal).to be_a(Faulty::Storage::Memory)
+    end
+
+    shared_examples 'delegator to internal' do
+      let(:circuit) { Faulty::Circuit.new('test', notifier: notifier) }
+      it do
+        marker = Object.new
+        expected = receive(action).and_return(marker)
+        args.empty? ? expected.with(no_args) : expected.with(*args)
+        expect(internal).to expected
+        expect(auto_wire.public_send(action, *args)).to eq(marker)
+      end
+    end
+
+    describe '#open' do
+      let(:action) { :open }
+      let(:args) { [circuit, Faulty.current_time] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#reopen' do
+      let(:action) { :reopen }
+      let(:args) { [circuit, Faulty.current_time, Faulty.current_time - 300] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#close' do
+      let(:action) { :close }
+      let(:args) { [circuit] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#lock' do
+      let(:action) { :lock }
+      let(:args) { [circuit, :open] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#unlock' do
+      let(:action) { :unlock }
+      let(:args) { [circuit] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#reset' do
+      let(:action) { :reset }
+      let(:args) { [circuit] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#status' do
+      let(:action) { :status }
+      let(:args) { [circuit] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#history' do
+      let(:action) { :history }
+      let(:args) { [circuit] }
+
+      it_behaves_like 'delegator to internal'
+    end
+
+    describe '#list' do
+      let(:action) { :list }
+      let(:args) { [] }
+
+      it_behaves_like 'delegator to internal'
+    end
+  end
+
+  context 'with a fault-tolerant backend' do
+    let(:backend) { Faulty::Storage::Memory.new }
+
+    it 'delegates directly if a fault-tolerant backend is given' do
+      expect(internal).to eq(backend)
+    end
+  end
+
+  context 'with a non-fault-tolerant backend' do
+    let(:backend) { Faulty::Storage::Redis.new }
+
+    it 'is fault tolerant' do
+      expect(auto_wire).to be_fault_tolerant
+    end
+
+    it 'wraps in FaultTolerantProxy and CircuitProxy' do
+      expect(internal).to be_a(Faulty::Storage::FaultTolerantProxy)
+
+      circuit_proxy = internal.instance_variable_get(:@storage)
+      expect(circuit_proxy).to be_a(Faulty::Storage::CircuitProxy)
+
+      original = circuit_proxy.instance_variable_get(:@storage)
+      expect(original).to eq(backend)
+    end
+  end
+
+  context 'with a fault-tolerant array' do
+    let(:redis_storage) { Faulty::Storage::Redis.new }
+    let(:mem_storage) { Faulty::Storage::Memory.new }
+    let(:backend) { [redis_storage, mem_storage] }
+
+    it 'creates a FallbackChain' do
+      expect(internal).to be_a(Faulty::Storage::FallbackChain)
+
+      storages = internal.instance_variable_get(:@storages)
+      expect(storages[0]).to be_a(Faulty::Storage::CircuitProxy)
+      expect(storages[0].instance_variable_get(:@storage)).to eq(redis_storage)
+      expect(storages[1]).to eq(mem_storage)
+    end
+  end
+
+  context 'with a non-fault-tolerant array' do
+    let(:redis_storage1) { Faulty::Storage::Redis.new }
+    let(:redis_storage2) { Faulty::Storage::Redis.new }
+    let(:backend) { [redis_storage1, redis_storage2] }
+
+    it 'creates a FallbackChain inside a FaultTolerantProxy' do
+      expect(internal).to be_a(Faulty::Storage::FaultTolerantProxy)
+
+      chain = internal.instance_variable_get(:@storage)
+      expect(chain).to be_a(Faulty::Storage::FallbackChain)
+
+      storages = chain.instance_variable_get(:@storages)
+      expect(storages[0]).to be_a(Faulty::Storage::CircuitProxy)
+      expect(storages[0].instance_variable_get(:@storage)).to eq(redis_storage1)
+      expect(storages[1]).to be_a(Faulty::Storage::CircuitProxy)
+      expect(storages[1].instance_variable_get(:@storage)).to eq(redis_storage2)
+    end
+  end
+end

--- a/spec/storage/circuit_proxy_spec.rb
+++ b/spec/storage/circuit_proxy_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Storage::CircuitProxy do
+  let(:notifier) { Faulty::Events::Notifier.new }
+  let(:circuit) { Faulty::Circuit.new('test') }
+  let(:internal_circuit) { Faulty::Circuit.new('internal', sample_threshold: 2) }
+
+  let(:failing_storage) do
+    Class.new do
+      def method_missing(*_args) # rubocop:disable Style/MethodMissingSuper
+        raise 'fail'
+      end
+
+      def respond_to_missing?(*_args)
+        true
+      end
+    end
+  end
+
+  it 'trips its internal circuit when storage fails repeatedly' do
+    backend = failing_storage.new
+    proxy = described_class.new(backend, notifier: notifier, circuit: internal_circuit)
+
+    begin
+      2.times { proxy.entry(circuit, Faulty.current_time, true) }
+    rescue Faulty::CircuitFailureError
+      nil
+    end
+
+    expect { proxy.entry(circuit, Faulty.current_time, true) }
+      .to raise_error(Faulty::CircuitTrippedError)
+  end
+end

--- a/spec/storage/fallback_chain_spec.rb
+++ b/spec/storage/fallback_chain_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Storage::FallbackChain do
+  let(:failing_class) do
+    Class.new do
+      def method_missing(_method, *_args) # rubocop:disable Style/MethodMissingSuper
+        raise 'fail'
+      end
+
+      def respond_to_missing?(_method, _include_all = false)
+        true
+      end
+    end
+  end
+
+  let(:failing) { failing_class.new }
+  let(:memory) { Faulty::Storage::Memory.new }
+  let(:memory2) { Faulty::Storage::Memory.new }
+  let(:notifier) { Faulty::Events::Notifier.new }
+  let(:circuit) { Faulty::Circuit.new('test') }
+  let(:succeeding_chain) { described_class.new([memory, memory2], notifier: notifier) }
+  let(:partially_failing_chain) { described_class.new([failing, memory], notifier: notifier) }
+  let(:midway_failure_chain) { described_class.new([memory, failing, memory2], notifier: notifier) }
+  let(:long_chain) { described_class.new([failing, failing_class.new, memory], notifier: notifier) }
+  let(:failing_chain) { described_class.new([failing, failing_class.new], notifier: notifier) }
+
+  context 'with #entry' do
+    it 'calls only first storage when successful' do
+      status = succeeding_chain.entry(circuit, Faulty.current_time, true)
+      expect(status.state).to eq(:closed)
+      expect(memory.history(circuit).size).to eq(1)
+      expect(memory2.history(circuit).size).to eq(0)
+    end
+
+    it 'falls back to next storage after failure' do
+      expect(notifier).to receive(:notify)
+        .with(:storage_failure, circuit: circuit, action: :entry, error: be_a(RuntimeError))
+      status = partially_failing_chain.entry(circuit, Faulty.current_time, true)
+      expect(status.state).to eq(:closed)
+      expect(memory.history(circuit).size).to eq(1)
+
+      expect(notifier).to receive(:notify)
+        .with(:storage_failure, circuit: circuit, action: :history, error: be_a(RuntimeError))
+      expect(partially_failing_chain.history(circuit).size).to eq(1)
+    end
+
+    it 'chains fallbacks for multiple failures' do
+      expect(notifier).to receive(:notify)
+        .with(:storage_failure, circuit: circuit, action: :entry, error: be_a(RuntimeError))
+        .twice
+      status = long_chain.entry(circuit, Faulty.current_time, true)
+      expect(status.state).to eq(:closed)
+      expect(memory.history(circuit).size).to eq(1)
+
+      expect(notifier).to receive(:notify)
+        .with(:storage_failure, circuit: circuit, action: :history, error: be_a(RuntimeError))
+        .twice
+      expect(long_chain.history(circuit).size).to eq(1)
+    end
+
+    it 'raises error if all storages fail' do
+      expect do
+        failing_chain.entry(circuit, Faulty.current_time, true)
+      end.to raise_error(
+        Faulty::AllFailedError,
+        'Faulty::Storage::FallbackChain#entry failed for all storage backends: fail, fail'
+      )
+    end
+  end
+
+  context 'with #lock' do
+    it 'delegates to all when successful' do
+      succeeding_chain.lock(circuit, :open)
+      expect(memory.status(circuit).locked_open?).to eq(true)
+      expect(memory2.status(circuit).locked_open?).to eq(true)
+    end
+
+    it 'continues delegating after failure and raises' do
+      expect do
+        midway_failure_chain.lock(circuit, :open)
+      end.to raise_error(
+        Faulty::PartialFailureError,
+        'Faulty::Storage::FallbackChain#lock failed for some storage backends: fail'
+      )
+
+      expect(memory.status(circuit).locked_open?).to eq(true)
+      expect(memory2.status(circuit).locked_open?).to eq(true)
+    end
+
+    it 'raises error if all storages fail' do
+      expect do
+        failing_chain.lock(circuit, :open)
+      end.to raise_error(
+        Faulty::AllFailedError,
+        'Faulty::Storage::FallbackChain#lock failed for all storage backends: fail, fail'
+      )
+    end
+  end
+
+  shared_examples 'chained method' do
+    it 'calls only first storage when successful' do
+      chain = described_class.new([memory, instance_double(Faulty::Storage::Memory)], notifier: notifier)
+      marker = Object.new
+      expected = receive(action).and_return(marker)
+      args.empty? ? expected.with(no_args) : expected.with(*args)
+      expect(memory).to expected
+      expect(chain.public_send(action, *args)).to eq(marker)
+    end
+
+    it 'falls back to next storage after failure' do
+      event_payload = { action: action, error: be_a(RuntimeError) }
+      event_payload[:circuit] = circuit unless action == :list
+      expect(notifier).to receive(:notify).with(:storage_failure, event_payload)
+      marker = Object.new
+      expected = receive(action).and_return(marker)
+      args.empty? ? expected.with(no_args) : expected.with(*args)
+      expect(memory).to expected
+      expect(partially_failing_chain.public_send(action, *args)).to eq(marker)
+    end
+  end
+
+  shared_examples 'fan-out method' do
+    it 'calls all backends' do
+      chain = described_class.new([memory, memory2], notifier: notifier)
+      expected = receive(action)
+      args.empty? ? expected.with(no_args) : expected.with(*args)
+      expect(memory).to expected
+      expect(memory2).to expected
+      expect(chain.public_send(action, *args)).to eq(nil)
+    end
+  end
+
+  describe '#open' do
+    let(:action) { :open }
+    let(:args) { [circuit, Faulty.current_time] }
+
+    it_behaves_like 'chained method'
+  end
+
+  describe '#reopen' do
+    let(:action) { :reopen }
+    let(:args) { [circuit, Faulty.current_time, Faulty.current_time - 300] }
+
+    it_behaves_like 'chained method'
+  end
+
+  describe '#close' do
+    let(:action) { :close }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'chained method'
+  end
+
+  describe '#lock' do
+    let(:action) { :lock }
+    let(:args) { [circuit, :open] }
+
+    it_behaves_like 'fan-out method'
+  end
+
+  describe '#unlock' do
+    let(:action) { :unlock }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'fan-out method'
+  end
+
+  describe '#reset' do
+    let(:action) { :reset }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'fan-out method'
+  end
+
+  describe '#status' do
+    let(:action) { :status }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'chained method'
+  end
+
+  describe '#history' do
+    let(:action) { :history }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'chained method'
+  end
+
+  describe '#list' do
+    let(:action) { :list }
+    let(:args) { [] }
+
+    it_behaves_like 'chained method'
+  end
+
+  it 'is fault tolerant if any storage is fault tolerant' do
+    expect(described_class.new([Faulty::Storage::Redis.new, memory], notifier: notifier))
+      .to be_fault_tolerant
+  end
+
+  it 'is not fault tolerant if no storage is fault tolerant' do
+    expect(described_class.new(
+      [Faulty::Storage::Redis.new, Faulty::Storage::Redis.new],
+      notifier: notifier
+    )).not_to be_fault_tolerant
+  end
+end

--- a/spec/storage/fault_tolerant_proxy_spec.rb
+++ b/spec/storage/fault_tolerant_proxy_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Faulty::Storage::FaultTolerantProxy do
   let(:notifier) { Faulty::Events::Notifier.new }
 
-  let(:failing_storage) do
+  let(:failing_storage_class) do
     Class.new do
       def method_missing(*_args) # rubocop:disable Style/MethodMissingSuper
         raise 'fail'
@@ -15,32 +15,142 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
     end
   end
 
-  let(:fake_storage) do
-    Class.new do
-      def method_missing(*_args) # rubocop:disable Style/MethodMissingSuper
-        'fake'
-      end
-
-      def respond_to_missing?(*_args)
-        true
-      end
-    end
-  end
+  let(:failing_storage) { failing_storage_class.new }
+  let(:inner_storage) { Faulty::Storage::Memory.new }
+  let(:circuit) { Faulty::Circuit.new('test') }
 
   it 'delegates to storage when adding entry succeeds' do
-    status = described_class.new(fake_storage.new, notifier: notifier)
-      .entry(Faulty::Circuit.new('test'), Faulty.current_time, true)
-    expect(status).to eq('fake')
+    described_class.new(inner_storage, notifier: notifier)
+      .entry(circuit, Faulty.current_time, true)
+    expect(inner_storage.history(circuit).size).to eq(1)
   end
 
   it 'returns stub status when adding entry fails' do
-    status = described_class.new(failing_storage.new, notifier: notifier)
-      .entry(Faulty::Circuit.new('test'), Faulty.current_time, true)
+    expect(notifier).to receive(:notify)
+      .with(:storage_failure, circuit: circuit, action: :entry, error: instance_of(RuntimeError))
+    status = described_class.new(failing_storage, notifier: notifier)
+      .entry(circuit, Faulty.current_time, true)
     expect(status.stub).to eq(true)
   end
 
-  it 'returns empty list when storage fails' do
-    list = described_class.new(failing_storage.new, notifier: notifier).list
-    expect(list).to eq([])
+  it 'returns stub status when getting #status' do
+    expect(notifier).to receive(:notify)
+      .with(:storage_failure, circuit: circuit, action: :status, error: instance_of(RuntimeError))
+    status = described_class.new(failing_storage, notifier: notifier)
+      .status(circuit)
+    expect(status.stub).to eq(true)
+  end
+
+  shared_examples 'delegated action' do
+    it 'delegates success to inner storage' do
+      marker = Object.new
+      expected = receive(action).and_return(marker)
+      args.empty? ? expected.with(no_args) : expected.with(*args)
+      expect(inner_storage).to expected
+      result = described_class.new(inner_storage, notifier: notifier)
+        .public_send(action, *args)
+      expect(result).to eq(marker)
+    end
+  end
+
+  shared_examples 'unsafe action' do
+    it 'raises error on failure' do
+      expect do
+        described_class.new(failing_storage, notifier: notifier).public_send(action, *args)
+      end.to raise_error('fail')
+    end
+
+    it_behaves_like 'delegated action'
+  end
+
+  shared_examples 'safely wrapped action' do
+    it 'catches error and returns false' do
+      expect(notifier).to receive(:notify)
+        .with(:storage_failure, circuit: circuit, action: action, error: instance_of(RuntimeError))
+      result = described_class.new(failing_storage, notifier: notifier)
+        .public_send(action, *args)
+      expect(result).to eq(false)
+    end
+
+    it_behaves_like 'delegated action'
+  end
+
+  describe '#open' do
+    let(:action) { :open }
+    let(:args) { [circuit, Faulty.current_time] }
+
+    it_behaves_like 'safely wrapped action'
+  end
+
+  describe '#reopen' do
+    let(:action) { :reopen }
+    let(:args) { [circuit, Faulty.current_time, Faulty.current_time - 300] }
+
+    it_behaves_like 'safely wrapped action'
+  end
+
+  describe '#close' do
+    let(:action) { :close }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'safely wrapped action'
+  end
+
+  describe '#lock' do
+    let(:action) { :lock }
+    let(:args) { [circuit, :open] }
+
+    it_behaves_like 'unsafe action'
+  end
+
+  describe '#unlock' do
+    let(:action) { :unlock }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'unsafe action'
+  end
+
+  describe '#reset' do
+    let(:action) { :reset }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'unsafe action'
+  end
+
+  describe '#history' do
+    let(:action) { :history }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'unsafe action'
+  end
+
+  describe '#list' do
+    let(:action) { :list }
+    let(:args) { [] }
+
+    it_behaves_like 'unsafe action'
+  end
+
+  it 'raises when storage fails while getting list' do
+    expect do
+      described_class.new(failing_storage, notifier: notifier).list
+    end.to raise_error('fail')
+  end
+
+  it 'is fault tolerant for non-fault-tolerant storage' do
+    fault_tolerant = described_class.new(Faulty::Storage::Redis.new, notifier: notifier)
+    expect(fault_tolerant).to be_fault_tolerant
+  end
+
+  describe '.wrap' do
+    it 'returns fault-tolerant storage unmodified' do
+      memory = Faulty::Storage::Memory.new
+      expect(described_class.wrap(memory, notifier: notifier)).to eq(memory)
+    end
+
+    it 'wraps fault-tolerant cache' do
+      redis = Faulty::Storage::Redis.new
+      expect(described_class.wrap(redis, notifier: notifier)).to be_a(described_class)
+    end
   end
 end

--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 require 'connection_pool'
+require 'redis'
 
 RSpec.describe Faulty::Storage::Redis do
   subject(:storage) { described_class.new(**options.merge(client: client)) }
 
   let(:options) { {} }
-  let(:client) { Redis.new }
+  let(:client) { Redis.new(timeout: 1) }
   let(:circuit) { Faulty::Circuit.new('test', storage: storage) }
 
-  after { circuit.reset! }
+  after { circuit&.reset! }
 
   context 'with default options' do
     subject(:storage) { described_class.new }
@@ -42,6 +43,55 @@ RSpec.describe Faulty::Storage::Redis do
         storage.open(circuit, Faulty.current_time)
       end
       expect(result.count { |r| r }).to eq(1)
+    end
+  end
+
+  context 'when Redis has high timeout' do
+    let(:client) { Redis.new(timeout: 5) }
+
+    it 'prints timeout warning' do
+      timeouts = { connect_timeout: 5.0, read_timeout: 5.0, write_timeout: 5.0 }
+      expect { storage }.to output(/Your options are:\n#{timeouts}/).to_stderr
+    end
+  end
+
+  context 'when Redis has high reconnect_attempts' do
+    let(:client) { Redis.new(timeout: 1, reconnect_attempts: 3) }
+
+    it 'prints reconnect_attempts warning' do
+      expect { storage }.to output(/Your setting is 3/).to_stderr
+    end
+  end
+
+  context 'when ConnectionPool has high timeout' do
+    let(:client) do
+      ConnectionPool.new(timeout: 6) { Redis.new(timeout: 1) }
+    end
+
+    it 'prints timeout warning' do
+      expect { storage }.to output(/Your setting is 6/).to_stderr
+    end
+  end
+
+  context 'when ConnectionPool Redis client has high timeout' do
+    let(:client) do
+      ConnectionPool.new(timeout: 1) { Redis.new(timeout: 7) }
+    end
+
+    it 'prints Redis timeout warning' do
+      timeouts = { connect_timeout: 7.0, read_timeout: 7.0, write_timeout: 7.0 }
+      expect { storage }.to output(/Your options are:\n#{timeouts}/).to_stderr
+    end
+  end
+
+  context 'when an error is raised while checking settings' do
+    let(:circuit) { nil }
+    let(:client) do
+      ConnectionPool.new(timeout: 1) { raise 'fail' }
+    end
+
+    it 'warns and continues' do
+      expect { storage }.to output(/while checking client options: fail/).to_stderr
     end
   end
 end


### PR DESCRIPTION
Add CircuitProxy for wrapping storage and caches in an internal circuit
----------------------

The purpose of circuits is to create separation from the app and its
dependencies, but we were breaking that by creating a hard link between
Faulty and its storage backends. Add CircuitProxy wrappers for storage
and cache so that they use internal circuits to break this hard
dependency.

We use circuits directly, outside the containing scope so that the internal
circuits have their own independent backend and do not create a loop.
This will simply use the Memory storage, so that we have a reliable
internal implementation that we can fall back on.

Add FallbackChain storage for falling back to stable storage
----------------------

Although in many cases it's not bad to default circuits to closed on
failure, we can imagine a cascading faulure scenario where disabling
circuits during storage failure could bring a system down. In that case,
we'd like to temporarily fall back to a stable, reliable storage
mechanism. That is what FallbackChain accomplishes. It will try each
storage in order of priority, and if one fails, it will try the next
one.

Some things like locks and resets are always delegated to all storage
backends.

Since we don't yet have a first-class in-memory storage implementation,
FallbackChain is not yet the default configuration, but if we can add a
circuit maximum to Storage::Memory, this could become a default wrapper
for all non-fault-tolerant storage backends.

Add timeout warnings to the Redis storage backend
----------------------

We don't have control over how the user configures their Redis client or
connection pool, so we do some introspection to check whether the
settings are appropriate for circuit breakers. If the user sets high
timeouts, we warn them on $stderr that they should change their
configuration. This warning can be disabled.

Better Fault-Tolerance Documentation
----------------------

Add individual documentation to the README about each fault tolerance
wrapper, and add better advice about how to use each backend.

Separate AutoWire Wrappers for cache/storage
----------------------

The logic to wrap storage and cache backends was getting too complex to
put in the base Faulty class, so we extract them to their own classes.
This also allows for better API documentaiton for how each one works.

Refactor Delegate Classes
----------------------

Refactor storage and cache wrappers to use Forwardable where appropriate
to remove custom code and make delegation more obvious.