### PR TITLE
Only run rubocop for Ruby 2.7 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rubocop
-
-
+        if: matrix.ruby == '2.7'
       - name: rspec with coverage
         uses: paambaati/codeclimate-action@v2.7.5
         env:


### PR DESCRIPTION
There is no reason to run it multiple times, and it's slow on some
ruby versions.