### PR TITLE
Add support for patches to core dependencies starting with redis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -9,6 +9,7 @@ require 'faulty/cache'
 require 'faulty/circuit'
 require 'faulty/error'
 require 'faulty/events'
+require 'faulty/patch'
 require 'faulty/result'
 require 'faulty/status'
 require 'faulty/storage'
@@ -66,7 +67,7 @@ class Faulty
     def [](name)
       raise UninitializedError unless @instances
 
-      @instances[name]
+      @instances[name.to_s]
     end
 
     # Register an instance to the global Faulty state
@@ -90,7 +91,7 @@ class Faulty
         instance = new(**config, &block)
       end
 
-      @instances.put_if_absent(name, instance)
+      @instances.put_if_absent(name.to_s, instance)
     end
 
     # Get the options for the default instance

--- a/lib/faulty/error.rb
+++ b/lib/faulty/error.rb
@@ -28,17 +28,25 @@ class Faulty
     end
   end
 
-  # The base error for all errors raised during circuit runs
-  #
-  class CircuitError < FaultyError
+  # Included in faulty circuit errors to provide common features for
+  # native and patched errors
+  module CircuitErrorBase
     attr_reader :circuit
 
+    # @param message [String]
+    # @param circuit [Circuit] The circuit that raised the error
     def initialize(message, circuit)
       message ||= %(circuit error for "#{circuit.name}")
       @circuit = circuit
 
       super(message)
     end
+  end
+
+  # The base error for all errors raised during circuit runs
+  #
+  class CircuitError < FaultyError
+    include CircuitErrorBase
   end
 
   # Raised when running a circuit that is already open

--- a/lib/faulty/patch.rb
+++ b/lib/faulty/patch.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'faulty/patch/base'
+
+class Faulty
+  # Automatic wrappers for common core dependencies like database connections
+  # or caches
+  module Patch
+    class << self
+      # Create a circuit from a configuration hash
+      #
+      # This is intended to be used in contexts where the user passes in
+      # something like a connection hash to a third-party library. For example
+      # the Redis patch hooks into the normal Redis connection options to add
+      # a `:faulty` key, which is a hash of faulty circuit options. This is
+      # slightly different from the normal Faulty circuit options because
+      # we also accept an `:instance` key which is a faulty instance.
+      #
+      # @example
+      #   # We pass in a faulty instance along with some circuit options
+      #   Patch.circuit_from_hash(
+      #     :mysql,
+      #     { host: 'localhost', faulty: {
+      #       name: 'my_mysql', # A custom circuit name can be included
+      #       instance: Faulty.new,
+      #       sample_threshold: 5
+      #       }
+      #     }
+      #   )
+      #
+      # @example
+      #   # instance can be a registered faulty instance referenced by a string
+      #   or symbol
+      #   Faulty.register(:db_faulty, Faulty.new)
+      #   Patch.circuit_from_hash(
+      #     :mysql,
+      #     { host: 'localhost', faulty: { instance: :db_faulty } }
+      #   )
+      # @example
+      #   # If instance is a hash with the key :constant, the value can be
+      #   # a global constant name containing a Faulty instance
+      #   DB_FAULTY = Faulty.new
+      #   Patch.circuit_from_hash(
+      #     :mysql,
+      #     { host: 'localhost', faulty: { instance: { constant: 'DB_FAULTY' } } }
+      #   )
+      #
+      # @example
+      #   # Certain patches may want to enforce certain options like :errors
+      #   # This can be done via hash or the usual block syntax
+      #   Patch.circuit_from_hash(:mysql,
+      #     { host: 'localhost', faulty: {} }
+      #     errors: [Mysql2::Error]
+      #   )
+      #
+      #   Patch.circuit_from_hash(:mysql,
+      #     { host: 'localhost', faulty: {} }
+      #   ) do |conf|
+      #     conf.errors = [Mysql2::Error]
+      #   end
+      #
+      # @param default_name [String] The default name for the circuit
+      # @param hash [Hash] A hash of user-provided options. Supports any circuit
+      #   option and these additional options
+      # @option hash [String] :name The circuit name. Defaults to `default_name`
+      # @option hash [Boolean] :patch_errors By default, circuit errors will be
+      #   subclasses of `options[:patched_error_module]`. The user can disable
+      #   this by setting this option to false.
+      # @option hash [Faulty, String, Symbol, Hash{ constant: String }] :instance
+      #   A reference to a faulty instance. See examples.
+      # @param options [Hash] Additional override options. Supports any circuit
+      #   option and these additional ones.
+      # @option options [Module] :patched_error_module The namespace module
+      #   for patched errors
+      # @yield [Circuit::Options] For setting override options in a block
+      # @return [Circuit, nil] The circuit if one was created
+      def circuit_from_hash(default_name, hash, **options, &block)
+        return unless hash
+
+        hash = symbolize_keys(hash)
+        name = hash.delete(:name) || default_name
+        patch_errors = hash.delete(:patch_errors) != false
+        error_module = options.delete(:patched_error_module)
+        hash[:error_module] ||= error_module if error_module && patch_errors
+        faulty = resolve_instance(hash.delete(:instance))
+        faulty.circuit(name, **hash, **options, &block)
+      end
+
+      # Create a full set of {CircuitError}s with a given base error class
+      #
+      # For patches that need their errors to be subclasses of a common base.
+      #
+      # @param namespace [Module] The module to define the error classes in
+      # @param base [Class] The base class for the error classes
+      # @return [void]
+      def define_circuit_errors(namespace, base)
+        circuit_error = Class.new(base) { include CircuitErrorBase }
+        namespace.const_set('CircuitError', circuit_error)
+        namespace.const_set('OpenCircuitError', Class.new(circuit_error))
+        namespace.const_set('CircuitFailureError', Class.new(circuit_error))
+        namespace.const_set('CircuitTrippedError', Class.new(circuit_error))
+      end
+
+      private
+
+      # Resolves a constant from a constant name or returns a default
+      #
+      # - If value is a string or symbol, gets a registered Faulty instance with that name
+      # - If value is a Hash with a key `:constant`, resolves the value to a global constant
+      # - If value is nil, gets Faulty.default
+      # - Otherwise, return value directly
+      #
+      # @param value [String, Symbol, Faulty, nil] The object or constant name to resolve
+      # @return [Object] The resolved Faulty instance
+      def resolve_instance(value)
+        case value
+        when String, Symbol
+          result = Faulty[value]
+          raise NameError, "No Faulty instance for #{value}" unless result
+
+          result
+        when Hash
+          const_name = value[:constant]
+          raise ArgumentError 'Missing hash key :constant for Faulty instance' unless const_name
+
+          Kernel.const_get(const_name)
+        when nil
+          Faulty.default
+        else
+          value
+        end
+      end
+
+      # Some config files may not suport symbol keys, so we convert the hash
+      # to use symbols so that users can pass in strings
+      #
+      # We cannot use transform_keys since we support Ruby < 2.5
+      #
+      # @param hash [Hash] A hash to convert
+      # @return [Hash] The hash with keys as symbols
+      def symbolize_keys(hash)
+        result = {}
+        hash.each do |key, val|
+          result[key.to_sym] = if val.is_a?(Hash)
+            symbolize_keys(val)
+          else
+            val
+          end
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/faulty/patch/base.rb
+++ b/lib/faulty/patch/base.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Patch
+    # Can be included in patch modules to provide common functionality
+    #
+    # The patch needs to set `@faulty_circuit`
+    #
+    # @example
+    #   module ThingPatch
+    #     include Faulty::Patch::Base
+    #
+    #     def initialize(options = {})
+    #       @faulty_circuit = Faulty::Patch.circuit_from_hash('thing', options[:faulty])
+    #     end
+    #
+    #     def do_something
+    #       faulty_run { super }
+    #     end
+    #   end
+    #
+    #   Thing.prepend(ThingPatch)
+    module Base
+      # Run a block wrapped by `@faulty_circuit`
+      #
+      # If `@faulty_circuit` is not set, the block will be run with no
+      # circuit.
+      #
+      # Nested calls to this method will only cause the circuit to be triggered
+      # once.
+      #
+      # @yield A block to run inside the circuit
+      # @return The block return value
+      def faulty_run
+        faulty_running_key = "faulty_running_#{object_id}"
+        return yield unless @faulty_circuit
+        return yield if Thread.current[faulty_running_key]
+
+        Thread.current[faulty_running_key] = true
+        @faulty_circuit.run { yield }
+      ensure
+        Thread.current[faulty_running_key] = false
+      end
+    end
+  end
+end

--- a/lib/faulty/patch/redis.rb
+++ b/lib/faulty/patch/redis.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'redis'
+
+class Faulty
+  module Patch
+    # Patch Redis to run all network IO in a circuit
+    #
+    # This module is not required by default
+    #
+    # Pass a `:faulty` key into your redis connection options to enable
+    # circuit protection. This hash is a hash of circuit options for the
+    # internal circuit. The hash may also have a `:instance` key, which is the
+    # faulty instance to create the circuit from. `Faulty.default` will be
+    # used if no instance is given. The `:instance` key can also reference a
+    # registered Faulty instance or a global constantso that it can be set
+    # from config files. See {Patch.circuit_from_hash}.
+    #
+    # @example
+    #   require 'faulty/patch/redis'
+    #
+    #   redis = Redis.new(url: 'redis://localhost:6379', faulty: {})
+    #   redis.connect # raises Faulty::CircuitError if connection fails
+    #
+    #   # If the faulty key is not given, no circuit is used
+    #   redis = Redis.new(url: 'redis://localhost:6379')
+    #   redis.connect # not protected by a circuit
+    #
+    # @see Patch.circuit_from_hash
+    module Redis
+      include Base
+
+      Patch.define_circuit_errors(self, ::Redis::BaseConnectionError)
+
+      # Patches Redis to add the `:faulty` key
+      def initialize(options = {})
+        @faulty_circuit = Patch.circuit_from_hash(
+          'redis',
+          options[:faulty],
+          errors: [::Redis::BaseConnectionError],
+          patched_error_module: Faulty::Patch::Redis
+        )
+
+        super
+      end
+
+      # The initial connection is protected by a circuit
+      def connect
+        faulty_run { super }
+      end
+
+      # Reads/writes to redis are protected
+      def io(&block)
+        faulty_run { super }
+      end
+    end
+  end
+end
+
+::Redis::Client.prepend(Faulty::Patch::Redis)

--- a/spec/faulty_spec.rb
+++ b/spec/faulty_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Faulty do
     expect(described_class[:new_instance]).to eq(instance)
   end
 
+  it 'accesses intances by string or symbol' do
+    described_class.init
+    instance = described_class.new
+    described_class.register(:symbol, instance)
+    expect(described_class['symbol']).to eq(instance)
+    described_class.register(:string, instance)
+    expect(described_class['string']).to eq(instance)
+  end
+
   it 'registers a named instance without default' do
     described_class.init(nil)
     instance = described_class.new

--- a/spec/patch/base_spec.rb
+++ b/spec/patch/base_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Patch::Base do
+  include described_class
+
+  let(:circuit) { Faulty::Circuit.new('test', **options) }
+  let(:options) { { cache: cache, storage: storage } }
+  let(:storage) { Faulty::Storage::Memory.new }
+  let(:cache) { Faulty::Cache::Mock.new }
+
+  before { @faulty_circuit = circuit }
+
+  it 'wraps block in a circuit' do
+    expect { faulty_run { raise 'fail' } }.to raise_error(Faulty::CircuitFailureError)
+  end
+
+  it 'does not double wrap errors' do
+    expect do
+      faulty_run { faulty_run { raise 'fail' } }
+    end.to raise_error(Faulty::CircuitFailureError)
+    expect(circuit.status.sample_size).to eq(1)
+  end
+end

--- a/spec/patch/redis_spec.rb
+++ b/spec/patch/redis_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Patch::Redis do
+  let(:faulty) { Faulty.new(listeners: []) }
+
+  let(:bad_url) { 'redis://127.0.0.1:9876' }
+  let(:bad_redis) { ::Redis.new(url: bad_url, faulty: { instance: faulty }) }
+  let(:good_redis)  { ::Redis.new(faulty: { instance: faulty }) }
+  let(:bad_unpatched_redis) do
+    ::Redis.new(url: bad_url, faulty: { instance: faulty, patch_errors: false })
+  end
+
+  it 'captures connection error' do
+    expect { bad_redis.client.connect }.to raise_error(Faulty::Patch::Redis::CircuitError)
+    expect(faulty.circuit('redis').status.failure_rate).to eq(1)
+  end
+
+  it 'captures connection error during command' do
+    expect { bad_redis.ping }.to raise_error(Faulty::Patch::Redis::CircuitError)
+    expect(faulty.circuit('redis').status.failure_rate).to eq(1)
+  end
+
+  it 'does not capture command error' do
+    expect { good_redis.foo }.to raise_error(Redis::CommandError)
+    expect(faulty.circuit('redis').status.failure_rate).to eq(0)
+  end
+
+  it 'raises unpatched errors if specified' do
+    expect { bad_unpatched_redis.ping }.to raise_error(Faulty::CircuitError)
+    expect(faulty.circuit('redis').status.failure_rate).to eq(1)
+  end
+end

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Patch do
+  let(:error_base) do
+    stub_const('TestErrorBase', Class.new(RuntimeError))
+  end
+
+  describe '.circuit_from_hash' do
+    let(:faulty) { Faulty.new }
+
+    let(:error_module) do
+      stub_const('TestErrors', Module.new)
+      described_class.define_circuit_errors(TestErrors, error_base)
+      TestErrors
+    end
+
+    after do
+      described_class.instance_variable_set(:@instances, nil)
+      described_class.instance_variable_set(:@default_instance, nil)
+    end
+
+    it 'can specify an instance' do
+      circuit = described_class.circuit_from_hash('test', { instance: faulty })
+      expect(faulty.circuit('test')).to eq(circuit)
+    end
+
+    it 'returns nil if hash is nil' do
+      circuit = described_class.circuit_from_hash('test', nil)
+      expect(circuit).to eq(nil)
+    end
+
+    it 'can specify a custom name' do
+      circuit = described_class.circuit_from_hash('test', { instance: faulty, name: 'my_test' })
+      expect(faulty.circuit('my_test')).to eq(circuit)
+    end
+
+    it 'passes circuit options to the circuit' do
+      circuit = described_class.circuit_from_hash('test', { instance: faulty, sample_threshold: 10 })
+      expect(circuit.options.sample_threshold).to eq(10)
+    end
+
+    it 'overrides hash options with keyword arg' do
+      circuit = described_class.circuit_from_hash(
+        'test',
+        {
+          instance: faulty,
+          sample_threshold: 10
+        },
+        sample_threshold: 20
+      )
+      expect(circuit.options.sample_threshold).to eq(20)
+    end
+
+    it 'overrides hash options with block' do
+      circuit = described_class.circuit_from_hash('test', { instance: faulty, sample_threshold: 10 }) do |config|
+        config.sample_threshold = 30
+      end
+      expect(circuit.options.sample_threshold).to eq(30)
+    end
+
+    context 'when patch_errors is enabled' do
+      it 'sets error_module' do
+        circuit = described_class.circuit_from_hash(
+          'test',
+          { instance: faulty },
+          patched_error_module: error_module
+        )
+        expect(circuit.options.error_module).to eq(error_module)
+      end
+    end
+
+    context 'when patch_errors is enabled but patched_error_module is missing' do
+      it 'uses Faulty error module' do
+        circuit = described_class.circuit_from_hash(
+          'test',
+          { instance: faulty, patch_errors: true }
+        )
+        expect(circuit.options.error_module).to eq(Faulty)
+      end
+    end
+
+    context 'when user sets error_module manually' do
+      it 'overrides patched_error_module' do
+        circuit = described_class.circuit_from_hash(
+          'test',
+          { instance: faulty, error_module: Faulty }
+        )
+        expect(circuit.options.error_module).to eq(Faulty)
+      end
+    end
+
+    context 'when patch_errors is disabled' do
+      it 'uses Faulty error module' do
+        circuit = described_class.circuit_from_hash(
+          'test',
+          { instance: faulty, patch_errors: false }
+        )
+        expect(circuit.options.error_module).to eq(Faulty)
+      end
+    end
+
+    context 'with Faulty.default' do
+      before { Faulty.init }
+
+      it 'can be run with empty hash' do
+        circuit = described_class.circuit_from_hash('test', {})
+        expect(Faulty.circuit('test')).to eq(circuit)
+      end
+    end
+
+    context 'with constant name' do
+      before { stub_const('MY_FAULTY', faulty) }
+
+      it 'gets instance by constant name' do
+        circuit = described_class.circuit_from_hash('test', { instance: { constant: :MY_FAULTY } })
+        expect(faulty.circuit('test')).to eq(circuit)
+      end
+
+      it 'can pass in string keys and constant name' do
+        circuit = described_class.circuit_from_hash('test', { 'instance' => { 'constant' => 'MY_FAULTY' } })
+        expect(faulty.circuit('test')).to eq(circuit)
+      end
+    end
+
+    context 'with symbol name' do
+      it 'gets registered instance by symbol' do
+        Faulty.register(:my_faulty, faulty)
+        circuit = described_class.circuit_from_hash('test', { instance: :my_faulty })
+        expect(faulty.circuit('test')).to eq(circuit)
+      end
+    end
+  end
+
+  describe '.define_circuit_errors' do
+    let(:namespace) do
+      stub_const('TestErrors', Module.new)
+    end
+
+    it 'creates all circuit error classes in the namespace' do
+      described_class.define_circuit_errors(namespace, error_base)
+      expect(TestErrors::CircuitError.superclass).to eq(TestErrorBase)
+      expect(TestErrors::CircuitError.ancestors).to include(Faulty::CircuitErrorBase)
+      expect(TestErrors::OpenCircuitError.superclass).to eq(TestErrors::CircuitError)
+      expect(TestErrors::CircuitFailureError.superclass).to eq(TestErrors::CircuitError)
+      expect(TestErrors::CircuitTrippedError.superclass).to eq(TestErrors::CircuitError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ if ENV['COVERAGE'] || ENV['CI']
 end
 
 require 'faulty'
+require 'faulty/patch/redis'
 require 'timecop'
 require 'redis'
 require 'connection_pool'


### PR DESCRIPTION
Potential answer for #13. I'd like to add a few patches for some common dependencies going forward.

One question that still needs to be answered is how will we support various versions of Redis (and other libraries). Will there be official support verified by CI, or is it good enough to test with the latest version? That might be something we need to answer on a case-by-case basis.