### PR TITLE
Allow setting default circuit options on Faulty instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ Faulty.init do |config|
   # AutoWire API docs for more details.
   config.cache = Faulty::Cache::Default.new
 
+  # A hash of default options to be used when creating new Circuits.
+  # See Circuit Options below for a full list of these
+  config.circuit_defaults = {}
+
   # The storage backend. By default, Faulty uses an in-memory store. For most
   # production applications, you'll want a more robust backend. Faulty also
   # provides Faulty::Storage::Redis for this.

--- a/spec/faulty_spec.rb
+++ b/spec/faulty_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe Faulty do
     expect(instance.circuit('test', cool_down: 302).options.cool_down).to eq(404)
   end
 
+  it 'passes options from itself to new circuits' do
+    instance = described_class.new(
+      circuit_defaults: { sample_threshold: 14, cool_down: 30 }
+    )
+    circuit = instance.circuit('test', cool_down: 10)
+    expect(circuit.options.cache).to eq(instance.options.cache)
+    expect(circuit.options.storage).to eq(instance.options.storage)
+    expect(circuit.options.notifier).to eq(instance.options.notifier)
+    expect(circuit.options.sample_threshold).to eq(14)
+    expect(circuit.options.cool_down).to eq(10)
+  end
+
   it 'converts symbol names to strings' do
     expect(instance.circuit(:test)).to eq(instance.circuit('test'))
   end


### PR DESCRIPTION
Also, passing cache, storage, or notifier to Faulty#circuit now behaves as
expected and overrides the Faulty instance options.