### PR TITLE
Allow passing custom circuit to AutoWire

### DIFF
--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -157,8 +157,8 @@ class Faulty
 
     def finalize
       self.notifier ||= Events::Notifier.new(listeners || [])
-      self.storage = Storage::AutoWire.new(storage, notifier: notifier)
-      self.cache = Cache::AutoWire.new(cache, notifier: notifier)
+      self.storage = Storage::AutoWire.wrap(storage, notifier: notifier)
+      self.cache = Cache::AutoWire.wrap(cache, notifier: notifier)
     end
 
     def required

--- a/lib/faulty/storage/auto_wire.rb
+++ b/lib/faulty/storage/auto_wire.rb
@@ -6,10 +6,17 @@ class Faulty
     #
     # Used by {Faulty#initialize} to setup sensible storage defaults
     class AutoWire
-      extend Forwardable
-
       # Options for {AutoWire}
+      #
+      # @!attribute [r] circuit
+      #   @return [Circuit] A circuit for {CircuitProxy} if one is created.
+      #     When modifying this, be careful to use only a reliable circuit
+      #     storage backend so that you don't introduce cascading failures.
+      # @!attribute [r] notifier
+      #   @return [Events::Notifier] A Faulty notifier. If given, listeners are
+      #     ignored.
       Options = Struct.new(
+        :circuit,
         :notifier
       ) do
         include ImmutableOptions
@@ -21,101 +28,79 @@ class Faulty
         end
       end
 
-      # Wrap storage backends with sensible defaults
-      #
-      # If the cache is `nil`, create a new {Memory} storage.
-      #
-      # If a single storage backend is given and is fault tolerant, leave it
-      # unmodified.
-      #
-      # If a single storage backend is given and is not fault tolerant, wrap it
-      # in a {CircuitProxy} and a {FaultTolerantProxy}.
-      #
-      # If an array of storage backends is given, wrap each non-fault-tolerant
-      # entry in a {CircuitProxy} and create a {FallbackChain}. If none of the
-      # backends in the array are fault tolerant, also wrap the {FallbackChain}
-      # in a {FaultTolerantProxy}.
-      #
-      # @todo Consider using a {FallbackChain} for non-fault-tolerant storages
-      #   by default. This would fallback to a {Memory} storage. It would
-      #   require a more conservative implementation of {Memory} that could
-      #   limit the number of circuits stored. For now, users need to manually
-      #   configure fallbacks.
-      #
-      # @param storage [Interface, Array<Interface>] A storage backed or array
-      #   of storage backends to setup.
-      # @param options [Hash] Attributes for {Options}
-      # @yield [Options] For setting options in a block
-      def initialize(storage, **options, &block)
-        @options = Options.new(options, &block)
-        @storage = if storage.nil?
-          Memory.new
-        elsif storage.is_a?(Array)
-          wrap_array(storage)
-        elsif !storage.fault_tolerant?
-          wrap_one(storage)
-        else
-          storage
+      class << self
+        # Wrap storage backends with sensible defaults
+        #
+        # If the cache is `nil`, create a new {Memory} storage.
+        #
+        # If a single storage backend is given and is fault tolerant, leave it
+        # unmodified.
+        #
+        # If a single storage backend is given and is not fault tolerant, wrap it
+        # in a {CircuitProxy} and a {FaultTolerantProxy}.
+        #
+        # If an array of storage backends is given, wrap each non-fault-tolerant
+        # entry in a {CircuitProxy} and create a {FallbackChain}. If none of the
+        # backends in the array are fault tolerant, also wrap the {FallbackChain}
+        # in a {FaultTolerantProxy}.
+        #
+        # @todo Consider using a {FallbackChain} for non-fault-tolerant storages
+        #   by default. This would fallback to a {Memory} storage. It would
+        #   require a more conservative implementation of {Memory} that could
+        #   limit the number of circuits stored. For now, users need to manually
+        #   configure fallbacks.
+        #
+        # @param storage [Interface, Array<Interface>] A storage backed or array
+        #   of storage backends to setup.
+        # @param options [Hash] Attributes for {Options}
+        # @yield [Options] For setting options in a block
+        def wrap(storage, **options, &block)
+          options = Options.new(options, &block)
+          if storage.nil?
+            Memory.new
+          elsif storage.is_a?(Array)
+            wrap_array(storage, options)
+          elsif !storage.fault_tolerant?
+            wrap_one(storage, options)
+          else
+            storage
+          end
         end
 
-        freeze
-      end
+        private
 
-      # @!method entry(circuit, time, success)
-      #   (see Faulty::Storage::Interface#entry)
-      #
-      # @!method open(circuit, opened_at)
-      #   (see Faulty::Storage::Interface#open)
-      #
-      # @!method reopen(circuit, opened_at, previous_opened_at)
-      #   (see Faulty::Storage::Interface#reopen)
-      #
-      # @!method close(circuit)
-      #   (see Faulty::Storage::Interface#close)
-      #
-      # @!method lock(circuit, state)
-      #   (see Faulty::Storage::Interface#lock)
-      #
-      # @!method unlock(circuit)
-      #   (see Faulty::Storage::Interface#unlock)
-      #
-      # @!method reset(circuit)
-      #   (see Faulty::Storage::Interface#reset)
-      #
-      # @!method status(circuit)
-      #   (see Faulty::Storage::Interface#status)
-      #
-      # @!method history(circuit)
-      #   (see Faulty::Storage::Interface#history)
-      #
-      # @!method list
-      #   (see Faulty::Storage::Interface#list)
-      #
-      def_delegators :@storage,
-        :entry, :open, :reopen, :close, :lock,
-        :unlock, :reset, :status, :history, :list
+        # Wrap an array of storage backends in a fault-tolerant FallbackChain
+        #
+        # @param [Array<Storage::Interface>] The array to wrap
+        # @param options [Options]
+        # @return [Storage::Interface] A fault-tolerant fallback chain
+        def wrap_array(array, options)
+          FaultTolerantProxy.wrap(FallbackChain.new(
+            array.map { |s| s.fault_tolerant? ? s : circuit_proxy(s, options) },
+            notifier: options.notifier
+          ), notifier: options.notifier)
+        end
 
-      def fault_tolerant?
-        true
-      end
+        # Wrap one storage backend in fault-tolerant backends
+        #
+        # @param [Storage::Interface] The storage to wrap
+        # @param options [Options]
+        # @return [Storage::Interface] A fault-tolerant storage backend
+        def wrap_one(storage, options)
+          FaultTolerantProxy.new(
+            circuit_proxy(storage, options),
+            notifier: options.notifier
+          )
+        end
 
-      private
-
-      # Wrap an array of storage backends in a fault-tolerant FallbackChain
-      #
-      # @return [Storage::Interface] A fault-tolerant fallback chain
-      def wrap_array(array)
-        FaultTolerantProxy.wrap(FallbackChain.new(
-          array.map { |s| s.fault_tolerant? ? s : CircuitProxy.new(s, notifier: @options.notifier) },
-          notifier: @options.notifier
-        ), notifier: @options.notifier)
-      end
-
-      def wrap_one(storage)
-        FaultTolerantProxy.new(
-          CircuitProxy.new(storage, notifier: @options.notifier),
-          notifier: @options.notifier
-        )
+        # Wrap storage in a CircuitProxy
+        #
+        # @param [Storage::Interface] The storage to wrap
+        # @param options [Options]
+        # @return [CircuitProxy]
+        def circuit_proxy(storage, options)
+          CircuitProxy.new(storage, circuit: options.circuit, notifier: options.notifier)
+        end
       end
     end
   end

--- a/spec/cache/auto_wire_spec.rb
+++ b/spec/cache/auto_wire_spec.rb
@@ -1,50 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe Faulty::Cache::AutoWire do
-  subject(:auto_wire) { described_class.new(backend, notifier: notifier) }
+  subject(:auto_wire) { described_class.wrap(backend, circuit: circuit, notifier: notifier) }
 
+  let(:circuit) { Faulty::Circuit.new('test') }
   let(:notifier) { Faulty::Events::Notifier.new }
   let(:backend) { nil }
-
-  # Typically it's a bad idea to test private interfaces, but in this case
-  # we're specifically interested in testing the implementation. The alternative
-  # would be to re-test functionality of each internal cache, and that seems
-  # like a worse alternative.
-  let(:internal) { auto_wire.instance_variable_get(:@cache) }
-
-  context 'with nil backend' do
-    it 'creates a new Default' do
-      expect(internal).to be_a(Faulty::Cache::Default)
-    end
-
-    shared_examples 'delegator to internal' do
-      it do
-        marker = Object.new
-        expect(internal).to receive(action).with(*args).and_return(marker)
-        expect(auto_wire.public_send(action, *args)).to eq(marker)
-      end
-    end
-
-    describe '#read' do
-      let(:action) { :read }
-      let(:args) { ['foo'] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#write' do
-      let(:action) { :write }
-      let(:args) { %w[foo val] }
-
-      it_behaves_like 'delegator to internal'
-    end
-  end
 
   context 'with a fault-tolerant backend' do
     let(:backend) { Faulty::Cache::Mock.new }
 
     it 'delegates directly if a fault-tolerant backend is given' do
-      expect(internal).to eq(backend)
+      expect(auto_wire).to eq(backend)
     end
   end
 
@@ -56,10 +23,11 @@ RSpec.describe Faulty::Cache::AutoWire do
     end
 
     it 'wraps in FaultTolerantProxy and CircuitProxy' do
-      expect(internal).to be_a(Faulty::Cache::FaultTolerantProxy)
+      expect(auto_wire).to be_a(Faulty::Cache::FaultTolerantProxy)
 
-      circuit_proxy = internal.instance_variable_get(:@cache)
+      circuit_proxy = auto_wire.instance_variable_get(:@cache)
       expect(circuit_proxy).to be_a(Faulty::Cache::CircuitProxy)
+      expect(circuit_proxy.options.circuit).to eq(circuit)
 
       original = circuit_proxy.instance_variable_get(:@cache)
       expect(original).to eq(backend)

--- a/spec/faulty_spec.rb
+++ b/spec/faulty_spec.rb
@@ -118,13 +118,13 @@ RSpec.describe Faulty do
     expect(instance.list_circuits).to match_array(%w[test1 test2])
   end
 
-  it 'wraps non-fault-tolerant storage in AutoWire' do
+  it 'wraps non-fault-tolerant storage in FaultTolerantProxy' do
     instance = described_class.new(storage: Faulty::Storage::Redis.new)
-    expect(instance.options.storage).to be_a(Faulty::Storage::AutoWire)
+    expect(instance.options.storage).to be_a(Faulty::Storage::FaultTolerantProxy)
   end
 
-  it 'wraps non-fault-tolerant cache in AutoWire' do
+  it 'wraps non-fault-tolerant cache in FaultTolerantProxy' do
     instance = described_class.new(cache: Faulty::Cache::Rails.new(nil))
-    expect(instance.options.cache).to be_a(Faulty::Cache::AutoWire)
+    expect(instance.options.cache).to be_a(Faulty::Cache::FaultTolerantProxy)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ end
 
 require 'faulty'
 require 'timecop'
+require 'redis'
+require 'connection_pool'
 
 require_relative 'support/concurrency'
 

--- a/spec/storage/auto_wire_spec.rb
+++ b/spec/storage/auto_wire_spec.rb
@@ -1,102 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe Faulty::Storage::AutoWire do
-  subject(:auto_wire) { described_class.new(backend, notifier: notifier) }
+  subject(:auto_wire) { described_class.wrap(backend, circuit: circuit, notifier: notifier) }
 
+  let(:circuit) { Faulty::Circuit.new('test') }
   let(:notifier) { Faulty::Events::Notifier.new }
   let(:backend) { nil }
-
-  # Typically it's a bad idea to test private interfaces, but in this case
-  # we're specifically interested in testing the implementation. The alternative
-  # would be to re-test functionality of each internal storage, and that seems
-  # like a worse alternative.
-  let(:internal) { auto_wire.instance_variable_get(:@storage) }
-
-  context 'with nil backend' do
-    it 'creates a new Memory' do
-      expect(internal).to be_a(Faulty::Storage::Memory)
-    end
-
-    shared_examples 'delegator to internal' do
-      let(:circuit) { Faulty::Circuit.new('test', notifier: notifier) }
-      it do
-        marker = Object.new
-        expected = receive(action).and_return(marker)
-        args.empty? ? expected.with(no_args) : expected.with(*args)
-        expect(internal).to expected
-        expect(auto_wire.public_send(action, *args)).to eq(marker)
-      end
-    end
-
-    describe '#open' do
-      let(:action) { :open }
-      let(:args) { [circuit, Faulty.current_time] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#reopen' do
-      let(:action) { :reopen }
-      let(:args) { [circuit, Faulty.current_time, Faulty.current_time - 300] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#close' do
-      let(:action) { :close }
-      let(:args) { [circuit] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#lock' do
-      let(:action) { :lock }
-      let(:args) { [circuit, :open] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#unlock' do
-      let(:action) { :unlock }
-      let(:args) { [circuit] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#reset' do
-      let(:action) { :reset }
-      let(:args) { [circuit] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#status' do
-      let(:action) { :status }
-      let(:args) { [circuit] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#history' do
-      let(:action) { :history }
-      let(:args) { [circuit] }
-
-      it_behaves_like 'delegator to internal'
-    end
-
-    describe '#list' do
-      let(:action) { :list }
-      let(:args) { [] }
-
-      it_behaves_like 'delegator to internal'
-    end
-  end
 
   context 'with a fault-tolerant backend' do
     let(:backend) { Faulty::Storage::Memory.new }
 
     it 'delegates directly if a fault-tolerant backend is given' do
-      expect(internal).to eq(backend)
+      expect(auto_wire).to eq(backend)
     end
   end
 
@@ -108,10 +23,11 @@ RSpec.describe Faulty::Storage::AutoWire do
     end
 
     it 'wraps in FaultTolerantProxy and CircuitProxy' do
-      expect(internal).to be_a(Faulty::Storage::FaultTolerantProxy)
+      expect(auto_wire).to be_a(Faulty::Storage::FaultTolerantProxy)
 
-      circuit_proxy = internal.instance_variable_get(:@storage)
+      circuit_proxy = auto_wire.instance_variable_get(:@storage)
       expect(circuit_proxy).to be_a(Faulty::Storage::CircuitProxy)
+      expect(circuit_proxy.options.circuit).to eq(circuit)
 
       original = circuit_proxy.instance_variable_get(:@storage)
       expect(original).to eq(backend)
@@ -124,9 +40,9 @@ RSpec.describe Faulty::Storage::AutoWire do
     let(:backend) { [redis_storage, mem_storage] }
 
     it 'creates a FallbackChain' do
-      expect(internal).to be_a(Faulty::Storage::FallbackChain)
+      expect(auto_wire).to be_a(Faulty::Storage::FallbackChain)
 
-      storages = internal.instance_variable_get(:@storages)
+      storages = auto_wire.instance_variable_get(:@storages)
       expect(storages[0]).to be_a(Faulty::Storage::CircuitProxy)
       expect(storages[0].instance_variable_get(:@storage)).to eq(redis_storage)
       expect(storages[1]).to eq(mem_storage)
@@ -139,9 +55,9 @@ RSpec.describe Faulty::Storage::AutoWire do
     let(:backend) { [redis_storage1, redis_storage2] }
 
     it 'creates a FallbackChain inside a FaultTolerantProxy' do
-      expect(internal).to be_a(Faulty::Storage::FaultTolerantProxy)
+      expect(auto_wire).to be_a(Faulty::Storage::FaultTolerantProxy)
 
-      chain = internal.instance_variable_get(:@storage)
+      chain = auto_wire.instance_variable_get(:@storage)
       expect(chain).to be_a(Faulty::Storage::FallbackChain)
 
       storages = chain.instance_variable_get(:@storages)


### PR DESCRIPTION
Backwards Compatibility: AutoWire.new has been replaced by AutoWire.wrap

- Switch From AutoWire.new to AutoWire.wrap to remove nesting (it's no
  longer a delegate)
- Document AutoWire better
- AutoWire now passes the `circuit` option to CircuitProxy

This allows easier construction of backends with custom CircuitProxy circuits:

```ruby
Faulty.init do |config|
  config.notifier = Faulty::Events::Notifier.new(config.listeners || [])
  config.storage = Faulty::Storage::AutoWire.wrap(
    Faulty::Storage::Redis.new,
    circuit: Faulty::Circuit.new('my_storage_circuit', cool_down: 15),
    notifier: config.notifier
  )
  config.cache = Faulty::Cache::AutoWire.wrap(
    Faulty::Storage::Redis.new,
    circuit: Faulty::Circuit.new('my_cache_circuit', cool_down: 15),
    notifier: config.notifier
  )
end
```