### PR TITLE
Improve storage #entries performance by returning entries

### DIFF
--- a/lib/faulty/storage/interface.rb
+++ b/lib/faulty/storage/interface.rb
@@ -14,7 +14,8 @@ class Faulty
       # @param circuit [Circuit] The circuit that ran
       # @param time [Integer] The unix timestamp for the run
       # @param success [Boolean] True if the run succeeded
-      # @return [Status] The circuit status after the run is added
+      # @return [Array<Array>] An array of the new history tuples after adding
+      #   the new entry, see {#history}
       def entry(circuit, time, success)
         raise NotImplementedError
       end

--- a/lib/faulty/storage/memory.rb
+++ b/lib/faulty/storage/memory.rb
@@ -89,7 +89,7 @@ class Faulty
           runs.push([time, success])
           runs.shift if runs.size > options.max_sample_size
         end
-        memory.status(circuit.options)
+        memory.runs.value
       end
 
       # Mark a circuit as open

--- a/spec/storage/fallback_chain_spec.rb
+++ b/spec/storage/fallback_chain_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Faulty::Storage::FallbackChain do
 
   context 'with #entry' do
     it 'calls only first storage when successful' do
-      status = succeeding_chain.entry(circuit, Faulty.current_time, true)
-      expect(status.state).to eq(:closed)
+      entries = succeeding_chain.entry(circuit, Faulty.current_time, true)
+      expect(entries.size).to eq(1)
       expect(memory.history(circuit).size).to eq(1)
       expect(memory2.history(circuit).size).to eq(0)
     end
@@ -35,8 +35,8 @@ RSpec.describe Faulty::Storage::FallbackChain do
     it 'falls back to next storage after failure' do
       expect(notifier).to receive(:notify)
         .with(:storage_failure, circuit: circuit, action: :entry, error: be_a(RuntimeError))
-      status = partially_failing_chain.entry(circuit, Faulty.current_time, true)
-      expect(status.state).to eq(:closed)
+      entries = partially_failing_chain.entry(circuit, Faulty.current_time, true)
+      expect(entries.size).to eq(1)
       expect(memory.history(circuit).size).to eq(1)
 
       expect(notifier).to receive(:notify)
@@ -48,8 +48,8 @@ RSpec.describe Faulty::Storage::FallbackChain do
       expect(notifier).to receive(:notify)
         .with(:storage_failure, circuit: circuit, action: :entry, error: be_a(RuntimeError))
         .twice
-      status = long_chain.entry(circuit, Faulty.current_time, true)
-      expect(status.state).to eq(:closed)
+      entries = long_chain.entry(circuit, Faulty.current_time, true)
+      expect(entries.size).to eq(1)
       expect(memory.history(circuit).size).to eq(1)
 
       expect(notifier).to receive(:notify)


### PR DESCRIPTION
It previously required returning a full status object which for Redis required multiple backend calls. Reduce that to just one pipelined call by just returning entries. This also simplifies some race conditions where the status could change out from under a circuit while it is processing a run.

BREAKING CHANGE:
Faulty::Storage::Interface must now return a history array instead of a circuit status object. Custom storage backends must be updated.

