### PR TITLE
Fix Storage::FaultTolerantProxy to return empty history on entries fail

### DIFF
--- a/lib/faulty/storage/fault_tolerant_proxy.rb
+++ b/lib/faulty/storage/fault_tolerant_proxy.rb
@@ -94,7 +94,7 @@ class Faulty
         @storage.entry(circuit, time, success)
       rescue StandardError => e
         options.notifier.notify(:storage_failure, circuit: circuit, action: :entry, error: e)
-        stub_status(circuit)
+        []
       end
 
       # Safely mark a circuit as open

--- a/spec/storage/fault_tolerant_proxy_spec.rb
+++ b/spec/storage/fault_tolerant_proxy_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
     expect(inner_storage.history(circuit).size).to eq(1)
   end
 
-  it 'returns stub status when adding entry fails' do
+  it 'returns empty history when adding entry fails' do
     expect(notifier).to receive(:notify)
       .with(:storage_failure, circuit: circuit, action: :entry, error: instance_of(RuntimeError))
-    status = described_class.new(failing_storage, notifier: notifier)
+    history = described_class.new(failing_storage, notifier: notifier)
       .entry(circuit, Faulty.current_time, true)
-    expect(status.stub).to eq(true)
+    expect(history).to eq([])
   end
 
   it 'returns stub status when getting #status' do


### PR DESCRIPTION
It was not correctly updated to return empty history on failure, causing
a circuit crash when an error was raised inside the #entries method.