### PR TITLE
docs, use correct state in description for skipped event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,7 @@ events. The full list of events is available from
 - `circuit_reopened` - A circuit execution cause the circuit to reopen from
   half-open. Payload: `circuit`, `error`.
 - `circuit_skipped` - A circuit execution was skipped because the circuit is
-  closed. Payload: `circuit`
+  open. Payload: `circuit`
 - `circuit_success` - A circuit execution was successful. Payload: `circuit`,
   `status`
 - `storage_failure` - A storage backend raised an error. Payload `circuit` (can


### PR DESCRIPTION
Going through the events I noticed that it stated "because the circuit is closed" in the case of `circuit_skipped`. I assume this meant to say "because the circuit is open" given that we do not execute it. Quick look at the code would confirm this behavior:

https://github.com/ParentSquare/faulty/blob/2408af2f9f399de79e0f048cd97c793f027cd21f/lib/faulty/circuit.rb#L224