### PR TITLE
Capture an error for BUSY redis backend when patched

### DIFF
--- a/spec/patch/redis_spec.rb
+++ b/spec/patch/redis_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Faulty::Patch::Redis do
 
   let(:bad_url) { 'redis://127.0.0.1:9876' }
   let(:bad_redis) { ::Redis.new(url: bad_url, faulty: { instance: faulty }) }
-  let(:good_redis)  { ::Redis.new(faulty: { instance: faulty }) }
+  let(:good_redis) { ::Redis.new(faulty: { instance: faulty }) }
   let(:bad_unpatched_redis) do
     ::Redis.new(url: bad_url, faulty: { instance: faulty, patch_errors: false })
   end
@@ -28,5 +28,47 @@ RSpec.describe Faulty::Patch::Redis do
   it 'raises unpatched errors if specified' do
     expect { bad_unpatched_redis.ping }.to raise_error(Faulty::CircuitError)
     expect(faulty.circuit('redis').status.failure_rate).to eq(1)
+  end
+
+  context 'with busy Redis instance' do
+    let(:busy_thread) do
+      begin
+        thread = Thread.new do
+          begin
+            ::Redis.new(read_timeout: 10).eval("while true do\n end")
+          rescue Redis::CommandError
+            # Ok when script is killed
+          end
+        end
+        # Try to force new thread to be scheduled
+        sleep 0.5
+        thread
+      end
+    end
+
+    before do
+      busy_thread
+    end
+
+    after do
+      begin
+        ::Redis.new(read_timeout: 10).call(%w[SCRIPT KILL])
+      rescue Redis::CommandError
+        # Ok if no script is running
+      end
+      busy_thread.join
+    end
+
+    it 'captures busy command error' do
+      expect { good_redis.ping }.to raise_error do |error|
+        expect(error).to be_a(Faulty::Patch::Redis::CircuitError)
+        expect(error.cause).to be_a(Faulty::Patch::Redis::BusyError)
+        expect(error.cause.message).to eq(
+          'BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.'
+        )
+      end
+
+      expect(faulty.circuit('redis').status.failure_rate).to be > 0
+    end
   end
 end


### PR DESCRIPTION
The redis main thread can easily be blocked by a stalled Lua script.
When that happens, the Redis client returns a CommandError. This
change modifies that error to its own unique error class. That allows
Faulty to capture it and treat it as a circuit failure.

Fixes #29