### PR TITLE
Fix a potential memory leak in patches

### DIFF
--- a/lib/faulty/patch/base.rb
+++ b/lib/faulty/patch/base.rb
@@ -39,7 +39,7 @@ class Faulty
         Thread.current[faulty_running_key] = true
         @faulty_circuit.run { yield }
       ensure
-        Thread.current[faulty_running_key] = false
+        Thread.current[faulty_running_key] = nil
       end
     end
   end


### PR DESCRIPTION
The recursion protection in Patch::Base set a fiber-local variable.
However when it was done it never unset the variable, instead it set it
to false. This could result in a slow memory leak as new Redis clients
were created.

This fix simply unsets the variable when unused.