### PR TITLE
Store circuit options in the backend when run

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ faulty.circuit('standalone_circuit')
 ```
 
 Calling `#circuit` on the instance still has the same memoization behavior that
-`Faulty.circuit` has, so subsequent calls to the same circuit will return a
+`Faulty.circuit` has, so subsequent runs for the same circuit will use a
 memoized circuit object.
 
 
@@ -733,7 +733,7 @@ Both options can even be specified together.
 ```ruby
 Faulty.circuit(
   'api',
-  errors: [ActiveRecord::ActiveRecordError]
+  errors: [ActiveRecord::ActiveRecordError],
   exclude: [ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique]
 ).run do
   # This only captures ActiveRecord::ActiveRecordError errors, but not
@@ -813,7 +813,7 @@ the options are retained within the context of each instance. All options given
 after the first call to `Faulty.circuit` (or `Faulty#circuit`) are ignored.
 
 ```ruby
-Faulty.circuit('api', rate_threshold: 0.7)
+Faulty.circuit('api', rate_threshold: 0.7).run { api.call }
 
 # These options are ignored since with already initialized the circuit
 circuit = Faulty.circuit('api', rate_threshold: 0.3)
@@ -821,7 +821,7 @@ circuit.options.rate_threshold # => 0.7
 ```
 
 This is because the circuit objects themselves are internally memoized, and are
-read-only once created.
+read-only once they are run.
 
 The following example represents the defaults for a new circuit:
 

--- a/faulty.gemspec
+++ b/faulty.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   # Only essential development tools and dependencies go here.
   # Other non-essential development dependencies go in the Gemfile.
   spec.add_development_dependency 'connection_pool', '~> 2.0'
+  spec.add_development_dependency 'json'
   spec.add_development_dependency 'redis', '>= 3.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
   # 0.81 is the last rubocop version with Ruby 2.3 support

--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -10,6 +10,7 @@ require 'faulty/circuit'
 require 'faulty/error'
 require 'faulty/events'
 require 'faulty/patch'
+require 'faulty/circuit_registry'
 require 'faulty/result'
 require 'faulty/status'
 require 'faulty/storage'
@@ -226,8 +227,8 @@ class Faulty
   # @param options [Hash] Attributes for {Options}
   # @yield [Options] For setting options in a block
   def initialize(**options, &block)
-    @circuits = Concurrent::Map.new
     @options = Options.new(options, &block)
+    @registry = CircuitRegistry.new(circuit_options)
   end
 
   # Create or retrieve a circuit
@@ -243,10 +244,7 @@ class Faulty
   # @return [Circuit] The new circuit or the existing circuit if it already exists
   def circuit(name, **options, &block)
     name = name.to_s
-    @circuits.compute_if_absent(name) do
-      options = circuit_options.merge(options)
-      Circuit.new(name, **options, &block)
-    end
+    @registry.retrieve(name, options, &block)
   end
 
   # Get a list of all circuit names

--- a/lib/faulty/cache/auto_wire.rb
+++ b/lib/faulty/cache/auto_wire.rb
@@ -21,8 +21,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def required
           %i[notifier]
         end

--- a/lib/faulty/cache/circuit_proxy.rb
+++ b/lib/faulty/cache/circuit_proxy.rb
@@ -26,8 +26,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def finalize
           raise ArgumentError, 'The circuit or notifier option must be given' unless notifier || circuit
 

--- a/lib/faulty/cache/fault_tolerant_proxy.rb
+++ b/lib/faulty/cache/fault_tolerant_proxy.rb
@@ -22,8 +22,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def required
           %i[notifier]
         end

--- a/lib/faulty/circuit_registry.rb
+++ b/lib/faulty/circuit_registry.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Faulty
+  # Used by Faulty instances to track and memoize Circuits
+  #
+  # Whenever a circuit is requested by `Faulty#circuit`, it calls
+  # `#retrieve`. That will return a resolved circuit if there is one, or
+  # otherwise, it will create a new circuit instance.
+  #
+  # Once any circuit is run, the circuit calls `#resolve`. That saves
+  # the instance into the registry. Any calls to `#retrieve` after
+  # the circuit is resolved will result in the same instance being returned.
+  #
+  # However, before a circuit is resolved, calling `Faulty#circuit` will result
+  # in a new Circuit instance being created for every call. If multiples of
+  # these call `resolve`, only the first one will "win" and be memoized.
+  class CircuitRegistry
+    def initialize(circuit_options)
+      @circuit_options = circuit_options
+      @circuit_options[:registry] = self
+      @circuits = Concurrent::Map.new
+    end
+
+    # Retrieve a memoized circuit with the same name, or if none is yet
+    # resolved, create a new one.
+    #
+    # @param name [String] The name of the circuit
+    # @param options [Hash] Options for {Circuit::Options}
+    # @yield [Circuit::Options] For setting options in a block
+    # @return [Circuit] The new or memoized circuit
+    def retrieve(name, options, &block)
+      @circuits.fetch(name) do
+        options = @circuit_options.merge(options)
+        Circuit.new(name, **options, &block)
+      end
+    end
+
+    # Save and memoize the given circuit as the "canonical" instance for
+    # the circuit name
+    #
+    # If the name is already resolved, this will be ignored
+    #
+    # @return [Circuit, nil] If this circuit name is already resolved, the
+    #   already-resolved circuit
+    def resolve(circuit)
+      @circuits.put_if_absent(circuit.name, circuit)
+    end
+  end
+end

--- a/lib/faulty/status.rb
+++ b/lib/faulty/status.rb
@@ -147,8 +147,6 @@ class Faulty
       failure_rate >= options.rate_threshold
     end
 
-    private
-
     def finalize
       raise ArgumentError, "state must be a symbol in #{self.class}::STATES" unless STATES.include?(state)
       unless lock.nil? || LOCKS.include?(lock)

--- a/lib/faulty/storage/auto_wire.rb
+++ b/lib/faulty/storage/auto_wire.rb
@@ -21,8 +21,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def required
           %i[notifier]
         end

--- a/lib/faulty/storage/circuit_proxy.rb
+++ b/lib/faulty/storage/circuit_proxy.rb
@@ -26,8 +26,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def finalize
           raise ArgumentError, 'The circuit or notifier option must be given' unless notifier || circuit
 
@@ -47,7 +45,20 @@ class Faulty
         @options = Options.new(options, &block)
       end
 
-      %i[entry open reopen close lock unlock reset status history list].each do |method|
+      %i[
+        get_options
+        set_options
+        entry
+        open
+        reopen
+        close
+        lock
+        unlock
+        reset
+        status
+        history
+        list
+      ].each do |method|
         define_method(method) do |*args|
           options.circuit.run { @storage.public_send(method, *args) }
         end

--- a/lib/faulty/storage/fallback_chain.rb
+++ b/lib/faulty/storage/fallback_chain.rb
@@ -30,8 +30,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def required
           %i[notifier]
         end
@@ -47,6 +45,24 @@ class Faulty
       def initialize(storages, **options, &block)
         @storages = storages
         @options = Options.new(options, &block)
+      end
+
+      # Get options from the first available storage backend
+      #
+      # @param (see Interface#get_options)
+      # @return (see Interface#get_options)
+      def get_options(circuit)
+        send_chain(:get_options, circuit) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :get_options, error: e)
+        end
+      end
+
+      # Try to set circuit options on all backends
+      #
+      # @param (see Interface#set_options)
+      # @return (see Interface#set_options)
+      def set_options(circuit, stored_options)
+        send_all(:set_options, circuit, stored_options)
       end
 
       # Create a circuit entry in the first available storage backend

--- a/lib/faulty/storage/fault_tolerant_proxy.rb
+++ b/lib/faulty/storage/fault_tolerant_proxy.rb
@@ -23,8 +23,6 @@ class Faulty
       ) do
         include ImmutableOptions
 
-        private
-
         def required
           %i[notifier]
         end
@@ -84,6 +82,30 @@ class Faulty
       #   @param (see Interface#list)
       #   @return (see Interface#list)
       def_delegators :@storage, :lock, :unlock, :reset, :history, :list
+
+      # Get circuit options safely
+      #
+      # @see Interface#get_options
+      # @param (see Interface#get_options)
+      # @return (see Interface#get_options)
+      def get_options(circuit)
+        @storage.get_options(circuit)
+      rescue StandardError => e
+        options.notifier.notify(:storage_failure, circuit: circuit, action: :get_options, error: e)
+        nil
+      end
+
+      # Set circuit options safely
+      #
+      # @see Interface#get_options
+      # @param (see Interface#set_options)
+      # @return (see Interface#set_options)
+      def set_options(circuit, stored_options)
+        @storage.set_options(circuit, stored_options)
+      rescue StandardError => e
+        options.notifier.notify(:storage_failure, circuit: circuit, action: :set_options, error: e)
+        nil
+      end
 
       # Add a history entry safely
       #

--- a/lib/faulty/storage/interface.rb
+++ b/lib/faulty/storage/interface.rb
@@ -6,6 +6,29 @@ class Faulty
     #
     # This is for documentation only and is not loaded
     class Interface
+      # Get the options stored for circuit
+      #
+      # They should be returned exactly as given by {#set_options}
+      #
+      # @return [Hash] A hash of the options stored by {#set_options}. The keys
+      #   must be symbols.
+      def get_options(circuit)
+        raise NotImplementedError
+      end
+
+      # Store the options for a circuit
+      #
+      # They should be returned exactly as given by {#set_options}
+      #
+      # @param circuit [Circuit] The circuit to set options for
+      # @param options [Hash<Symbol, Object>] A hash of symbol option names to
+      #   circuit options. These option values are guranteed to be primive
+      #   values.
+      # @return [void]
+      def set_options(circuit, stored_options)
+        raise NotImplementedError
+      end
+
       # Add a circuit run entry to storage
       #
       # The backend may choose to store this in whatever manner it chooses as
@@ -99,7 +122,7 @@ class Faulty
       # Reset the circuit to a fresh state
       #
       # Clears all circuit status including entries, state, locks,
-      # opened_at, and any other values that would affect Status.
+      # opened_at, options, and any other values that would affect Status.
       #
       # No concurrency gurantees are provided for resetting
       #

--- a/lib/faulty/storage/memory.rb
+++ b/lib/faulty/storage/memory.rb
@@ -33,8 +33,6 @@ class Faulty
       Options = Struct.new(:max_sample_size) do
         include ImmutableOptions
 
-        private
-
         def defaults
           { max_sample_size: 100 }
         end
@@ -43,7 +41,7 @@ class Faulty
       # The internal object for storing a circuit
       #
       # @private
-      MemoryCircuit = Struct.new(:state, :runs, :opened_at, :lock) do
+      MemoryCircuit = Struct.new(:state, :runs, :opened_at, :lock, :options) do
         def initialize
           self.state = Concurrent::Atom.new(:closed)
           self.runs = Concurrent::MVar.new([], dup_on_deref: true)
@@ -76,6 +74,24 @@ class Faulty
       def initialize(**options, &block)
         @circuits = Concurrent::Map.new
         @options = Options.new(options, &block)
+      end
+
+      # Get the options stored for circuit
+      #
+      # @see Interface#get_options
+      # @param (see Interface#get_options)
+      # @return (see Interface#get_options)
+      def get_options(circuit)
+        fetch(circuit).options
+      end
+
+      # Store the options for a circuit
+      #
+      # @see Interface#set_options
+      # @param (see Interface#set_options)
+      # @return (see Interface#set_options)
+      def set_options(circuit, stored_options)
+        fetch(circuit).options = stored_options
       end
 
       # Add an entry to storage

--- a/lib/faulty/storage/null.rb
+++ b/lib/faulty/storage/null.rb
@@ -11,6 +11,17 @@ class Faulty
         @instance
       end
 
+      # @param (see Interface#get_options)
+      # @return (see Interface#get_options)
+      def get_options(_circuit)
+        {}
+      end
+
+      # @param (see Interface#set_options)
+      # @return (see Interface#set_options)
+      def set_options(_circuit, _stored_options)
+      end
+
       # @param (see Interface#entry)
       # @return (see Interface#entry)
       def entry(_circuit, _time, _success)

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -245,6 +245,38 @@ RSpec.context :circuits do
       expect(result).to eq('cached')
     end
 
+    it 'initially fetches available options from storage' do
+      storage.set_options(circuit, cool_down: 5)
+      expect(circuit.options.cool_down).to eq(5)
+    end
+
+    it 'stores options in storage when run' do
+      circuit.run { 'ok' }
+      expect(storage.get_options(circuit)[:cool_down]).to eq(300)
+    end
+
+    it 'updates options from stored to given after running' do
+      circuit = Faulty::Circuit.new('test', **options, cool_down: 7)
+      storage.set_options(circuit, cool_down: 5)
+      expect(circuit.options.cool_down).to eq(5)
+      circuit.run { 'ok' }
+      expect(circuit.options.cool_down).to eq(7)
+    end
+
+    it 'gets status without setting options' do
+      circuit.status
+      expect(storage.get_options(circuit)).to eq(nil)
+    end
+
+    it 'locks circuit without setting options' do
+      circuit.lock_open!
+      expect(storage.get_options(circuit)).to eq(nil)
+    end
+
+    it 'gets default options if not stored' do
+      expect(circuit.options.cool_down).to eq(300)
+    end
+
     context 'with error_module' do
       let(:options) do
         {

--- a/spec/immutable_options_spec.rb
+++ b/spec/immutable_options_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Faulty::ImmutableOptions do
     Struct.new(:name, :cache, :storage) do
       include Faulty::ImmutableOptions
 
-      private
-
       def defaults
         { cache: 'default_cache' }
       end

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Faulty::Patch do
   end
 
   describe '.circuit_from_hash' do
-    let(:faulty) { Faulty.new }
+    let(:faulty) { Faulty.new(listeners: []) }
 
     let(:error_module) do
       stub_const('TestErrors', Module.new)
@@ -21,6 +21,7 @@ RSpec.describe Faulty::Patch do
 
     it 'can specify an instance' do
       circuit = described_class.circuit_from_hash('test', { instance: faulty })
+      circuit.run { 'ok' }
       expect(faulty.circuit('test')).to eq(circuit)
     end
 
@@ -31,11 +32,13 @@ RSpec.describe Faulty::Patch do
 
     it 'can specify a custom name' do
       circuit = described_class.circuit_from_hash('test', { instance: faulty, name: 'my_test' })
+      circuit.run { 'ok' }
       expect(faulty.circuit('my_test')).to eq(circuit)
     end
 
     it 'passes circuit options to the circuit' do
       circuit = described_class.circuit_from_hash('test', { instance: faulty, sample_threshold: 10 })
+      circuit.run { 'ok' }
       expect(circuit.options.sample_threshold).to eq(10)
     end
 
@@ -100,10 +103,11 @@ RSpec.describe Faulty::Patch do
     end
 
     context 'with Faulty.default' do
-      before { Faulty.init }
+      before { Faulty.init(listeners: []) }
 
       it 'can be run with empty hash' do
         circuit = described_class.circuit_from_hash('test', {})
+        circuit.run { 'ok' }
         expect(Faulty.circuit('test')).to eq(circuit)
       end
     end
@@ -113,11 +117,13 @@ RSpec.describe Faulty::Patch do
 
       it 'gets instance by constant name' do
         circuit = described_class.circuit_from_hash('test', { instance: { constant: :MY_FAULTY } })
+        circuit.run { 'ok' }
         expect(faulty.circuit('test')).to eq(circuit)
       end
 
       it 'can pass in string keys and constant name' do
         circuit = described_class.circuit_from_hash('test', { 'instance' => { 'constant' => 'MY_FAULTY' } })
+        circuit.run { 'ok' }
         expect(faulty.circuit('test')).to eq(circuit)
       end
     end
@@ -126,6 +132,7 @@ RSpec.describe Faulty::Patch do
       it 'gets registered instance by symbol' do
         Faulty.register(:my_faulty, faulty)
         circuit = described_class.circuit_from_hash('test', { instance: :my_faulty })
+        circuit.run { 'ok' }
         expect(faulty.circuit('test')).to eq(circuit)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ require 'faulty'
 require 'faulty/patch/redis'
 require 'timecop'
 require 'redis'
+require 'json'
 require 'connection_pool'
 
 begin

--- a/spec/storage/fallback_chain_spec.rb
+++ b/spec/storage/fallback_chain_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe Faulty::Storage::FallbackChain do
     end
   end
 
+  describe '#get_options' do
+    let(:action) { :get_options }
+    let(:args) { [circuit] }
+
+    it_behaves_like 'chained method'
+  end
+
+  describe '#set_options' do
+    let(:action) { :set_options }
+    let(:args) { [circuit, { cool_down: 5 }] }
+
+    it_behaves_like 'fan-out method'
+  end
+
   describe '#open' do
     let(:action) { :open }
     let(:args) { [circuit, Faulty.current_time] }

--- a/spec/storage/fault_tolerant_proxy_spec.rb
+++ b/spec/storage/fault_tolerant_proxy_spec.rb
@@ -69,15 +69,32 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
         .with(:storage_failure, circuit: circuit, action: action, error: instance_of(RuntimeError))
       result = described_class.new(failing_storage, notifier: notifier)
         .public_send(action, *args)
-      expect(result).to eq(false)
+      expect(result).to eq(retval)
     end
 
     it_behaves_like 'delegated action'
   end
 
+  describe '#get_options' do
+    let(:action) { :get_options }
+    let(:args) { [circuit] }
+    let(:retval) { nil }
+
+    it_behaves_like 'safely wrapped action'
+  end
+
+  describe '#set_options' do
+    let(:action) { :set_options }
+    let(:args) { [circuit, { cool_down: 3 }] }
+    let(:retval) { nil }
+
+    it_behaves_like 'safely wrapped action'
+  end
+
   describe '#open' do
     let(:action) { :open }
     let(:args) { [circuit, Faulty.current_time] }
+    let(:retval) { false }
 
     it_behaves_like 'safely wrapped action'
   end
@@ -85,6 +102,7 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
   describe '#reopen' do
     let(:action) { :reopen }
     let(:args) { [circuit, Faulty.current_time, Faulty.current_time - 300] }
+    let(:retval) { false }
 
     it_behaves_like 'safely wrapped action'
   end
@@ -92,6 +110,7 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
   describe '#close' do
     let(:action) { :close }
     let(:args) { [circuit] }
+    let(:retval) { false }
 
     it_behaves_like 'safely wrapped action'
   end


### PR DESCRIPTION
This change causes storage backends to store some options that are
required for calculating circuit status. This means that circuit
statuses can be retrieved accurately without having to manually set the
correct options.

TODO
-----------

- [x] Prevent `Faulty.circuit('foo')` from memoizing the default options
  when that isn't intended.

Fixes #25

BREAKING CHANGES
----------------------

- Added #get_options and #set_options to Faulty::Storage::Interface.
  These will need to be added to any custom backends
- Faulty::Storage::Interface#reset now requires removing options in
  addition to other stored values
- Circuit options will now be supplemented by stored options until they
  are run. This is technically a breaking change in behavior, although
  in most cases this should cause the expected result.
- Circuits are not memoized until they are run. Subsequent calls
  to `Faulty#circuit` can return different instances if the circuit is
  not run. However, once run, options are synchronized between
  instances, so likely this will not be a breaking change for most
  cases.