### PR TITLE
Add initial benchmarks and performance improvements

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'benchmark'
+require 'faulty'
+
+n = 100_000
+
+puts "Starting circuit benchmarks with #{n} iterations each\n\n"
+
+Benchmark.bm(25) do |b|
+  in_memory = Faulty.new(listeners: [])
+  b.report('memory storage') do
+    n.times { in_memory.circuit(:memory).run { true } }
+  end
+
+  b.report('memory storage failures') do
+    n.times do
+      begin
+        in_memory.circuit(:memory_fail, sample_threshold: n + 1).run { raise 'fail' }
+      rescue StandardError
+        # Expected to raise here
+      end
+    end
+  end
+
+  in_memory_large = Faulty.new(listeners: [], storage: Faulty::Storage::Memory.new(max_sample_size: 1000))
+  b.report('large memory storage') do
+    n.times { in_memory_large.circuit(:memory_large).run { true } }
+  end
+end
+
+n = 1_000_000
+
+puts "\n\nStarting extra benchmarks with #{n} iterations each\n\n"
+
+Benchmark.bm(25) do |b|
+  in_memory = Faulty.new(listeners: [])
+
+  log_listener = Faulty::Events::LogListener.new(Logger.new(File::NULL))
+  log_circuit = in_memory.circuit(:log_listener)
+  log_status = log_circuit.status
+  b.report('log listener success') do
+    n.times { log_listener.handle(:circuit_success, circuit: log_circuit, status: log_status) }
+  end
+
+  log_error = StandardError.new('test error')
+  b.report('log listener failure') do
+    n.times { log_listener.handle(:circuit_failure, error: log_error, circuit: log_circuit, status: log_status) }
+  end
+end

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -319,12 +319,10 @@ class Faulty
 
     # @return [Boolean] True if the circuit transitioned to closed
     def success!(status)
-      entries = storage.entry(self, Faulty.current_time, true)
-      status = Status.from_entries(entries, **status.to_h)
-      closed = false
-      closed = close! if should_close?(status)
+      storage.entry(self, Faulty.current_time, true)
+      closed = close! if status.half_open?
 
-      options.notifier.notify(:circuit_success, circuit: self, status: status)
+      options.notifier.notify(:circuit_success, circuit: self)
       closed
     end
 
@@ -368,16 +366,6 @@ class Faulty
       closed = storage.close(self)
       options.notifier.notify(:circuit_closed, circuit: self) if closed
       closed
-    end
-
-    # Test whether we should close after a successful run
-    #
-    # Currently this is always true if the circuit is half-open, which is the
-    # traditional behavior for a circuit-breaker
-    #
-    # @return [Boolean] True if we should close the circuit from half-open
-    def should_close?(status)
-      status.half_open?
     end
 
     # Read from the cache if it is configured

--- a/lib/faulty/events.rb
+++ b/lib/faulty/events.rb
@@ -17,6 +17,8 @@ class Faulty
       circuit_success
       storage_failure
     ].freeze
+
+    EVENT_SET = Set.new(EVENTS)
   end
 end
 

--- a/lib/faulty/events/callback_listener.rb
+++ b/lib/faulty/events/callback_listener.rb
@@ -23,7 +23,7 @@ class Faulty
       # @param (see ListenerInterface#handle)
       # @return [void]
       def handle(event, payload)
-        return unless EVENTS.include?(event)
+        return unless EVENT_SET.include?(event)
         return unless @handlers.key?(event)
 
         @handlers[event].each do |handler|

--- a/lib/faulty/events/honeybadger_listener.rb
+++ b/lib/faulty/events/honeybadger_listener.rb
@@ -8,11 +8,19 @@ class Faulty
     #
     # The honeybadger gem must be available.
     class HoneybadgerListener
+      HONEYBADGER_EVENTS = Set[
+        :circuit_failure,
+        :circuit_opened,
+        :circuit_reopened,
+        :cache_failure,
+        :storage_failure
+      ].freeze
+
       # (see ListenerInterface#handle)
       def handle(event, payload)
-        return unless EVENTS.include?(event)
+        return unless HONEYBADGER_EVENTS.include?(event)
 
-        send(event, payload) if respond_to?(event, true)
+        send(event, payload)
       end
 
       private

--- a/lib/faulty/events/log_listener.rb
+++ b/lib/faulty/events/log_listener.rb
@@ -16,9 +16,9 @@ class Faulty
 
       # (see ListenerInterface#handle)
       def handle(event, payload)
-        return unless EVENTS.include?(event)
+        return unless EVENT_SET.include?(event)
 
-        send(event, payload) if respond_to?(event, true)
+        send(event, payload)
       end
 
       private
@@ -79,8 +79,10 @@ class Faulty
       end
 
       def log(level, msg, action, extra = {})
-        extra_str = extra.map { |k, v| "#{k}=#{v}" }.join(' ')
-        logger.public_send(level, "#{msg}: #{action} #{extra_str}")
+        @logger.public_send(level) do
+          extra_str = extra.map { |k, v| "#{k}=#{v}" }.join(' ')
+          "#{msg}: #{action} #{extra_str}"
+        end
       end
     end
   end

--- a/lib/faulty/status.rb
+++ b/lib/faulty/status.rb
@@ -64,10 +64,17 @@ class Faulty
     #   sample_size
     # @return [Status]
     def self.from_entries(entries, **hash)
+      window_start = Faulty.current_time - hash[:options].evaluation_window
+      size = entries.size
+      i = 0
       failures = 0
       sample_size = 0
-      entries.each do |(time, success)|
-        next unless time > Faulty.current_time - hash[:options].evaluation_window
+
+      # This is a hot loop, and while is slightly faster than each
+      while i < size
+        time, success = entries[i]
+        i += 1
+        next unless time > window_start
 
         sample_size += 1
         failures += 1 unless success


### PR DESCRIPTION
Adding benchmarks and fixing a few obvious performance problems

### Master Branch

```
Starting circuit benchmarks with 100000 iterations each

                                user     system      total        real
memory storage             19.241159   0.119957  19.361116 ( 19.479319)
memory storage failures    20.985789   0.131852  21.117641 ( 21.250503)
large memory storage      163.561468   1.452444 165.013912 (166.736117)


Starting extra benchmarks with 1000000 iterations each

                                user     system      total        real
log listener success        2.939421   0.050259   2.989680 (  3.060945)
log listener failure        4.452318   0.050580   4.502898 (  4.568050)

```

### This Branch

```
Starting circuit benchmarks with 100000 iterations each

                                user     system      total        real
memory storage              2.776031   0.019284   2.795315 (  2.806418)
memory storage failures     5.945809   0.025429   5.971238 (  5.990029)
large memory storage       10.722527   0.097206  10.819733 ( 10.851631)


Starting extra benchmarks with 1000000 iterations each

                                user     system      total        real
log listener success        1.148061   0.004904   1.152965 (  1.156238)
log listener failure        1.474808   0.004889   1.479697 (  1.484117)
```

## Breaking Changes

The `circuit_success` event no longer contains the `status` value. Computing this value was causing performance problems.