### PR TITLE
Add cause message to CircuitTrippedError

### DIFF
--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -398,9 +398,9 @@ class Faulty
       raise if options.exclude.any? { |ex| e.is_a?(ex) }
 
       if cached_value.nil?
-        raise options.error_module::CircuitTrippedError.new(nil, self) if failure!(status, e)
+        raise options.error_module::CircuitTrippedError.new(e.message, self) if failure!(status, e)
 
-        raise options.error_module::CircuitFailureError.new(nil, self)
+        raise options.error_module::CircuitFailureError.new(e.message, self)
       else
         cached_value
       end

--- a/lib/faulty/error.rb
+++ b/lib/faulty/error.rb
@@ -36,10 +36,11 @@ class Faulty
     # @param message [String]
     # @param circuit [Circuit] The circuit that raised the error
     def initialize(message, circuit)
-      message ||= %(circuit error for "#{circuit.name}")
-      @circuit = circuit
+      full_message = %(circuit error for "#{circuit.name}")
+      full_message = %(#{full_message}: #{message}) if message
 
-      super(message)
+      @circuit = circuit
+      super(full_message)
     end
   end
 

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -57,7 +57,7 @@ RSpec.context :circuits do
         circuit.run { raise 'failed' }
       end.to raise_error(
         an_instance_of(Faulty::CircuitFailureError)
-        .and(having_attributes(message: 'circuit error for "test"', circuit: circuit))
+        .and(having_attributes(message: 'circuit error for "test": failed', circuit: circuit))
       )
     end
 
@@ -67,7 +67,7 @@ RSpec.context :circuits do
         circuit.run { raise 'failed' }
       end.to raise_error(
         an_instance_of(Faulty::CircuitTrippedError)
-        .and(having_attributes(message: 'circuit error for "test"', circuit: circuit))
+        .and(having_attributes(message: 'circuit error for "test": failed', circuit: circuit))
       )
     end
 


### PR DESCRIPTION
When we rescue an exception during a circuit failure, we can add the failure cause message to the CircuitTrippedError message.