### PR TITLE
Record failures for cache hits

### DIFF
--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -397,10 +397,13 @@ class Faulty
     rescue *options.errors => e
       raise if options.exclude.any? { |ex| e.is_a?(ex) }
 
+      opened = failure!(status, e)
       if cached_value.nil?
-        raise options.error_module::CircuitTrippedError.new(e.message, self) if failure!(status, e)
-
-        raise options.error_module::CircuitFailureError.new(e.message, self)
+        if opened
+          raise options.error_module::CircuitTrippedError.new(e.message, self)
+        else
+          raise options.error_module::CircuitFailureError.new(e.message, self)
+        end
       else
         cached_value
       end

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -196,6 +196,8 @@ RSpec.context :circuits do
       Timecop.freeze(Time.now + 5000)
       result = circuit.run(cache: 'test_cache') { raise 'fail' }
       expect(result).to eq('cached')
+      # Still records the failure
+      expect(circuit.history.last[1]).to eq(false)
     end
 
     it 'raises unwrapped error if error is excluded' do


### PR DESCRIPTION
If the cache was hit, but it is time to refresh, we still run a circuit.
However, if the circuit then fails, it still returns the cached value.
In this scenario, we weren't recording the failure, but instead, simply
returning the cached value without recording success or failure at all.

Fix this so that if the circuit fails, it will always record that
failure even if it returns a cached value.