### PR TITLE
Fix crash for older versions of concurrent-ruby

### DIFF
--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -2,7 +2,7 @@
 
 require 'securerandom'
 require 'forwardable'
-require 'concurrent-ruby'
+require 'concurrent'
 
 require 'faulty/immutable_options'
 require 'faulty/cache'


### PR DESCRIPTION
Older versions did not support requiring by the name concurrent-ruby.
The correct name to require it is "concurrent".