### PR TITLE
Return status conditionally for Storage::Interface#entry

### DIFF
--- a/lib/faulty/storage/fallback_chain.rb
+++ b/lib/faulty/storage/fallback_chain.rb
@@ -69,8 +69,8 @@ class Faulty
       #
       # @param (see Interface#entry)
       # @return (see Interface#entry)
-      def entry(circuit, time, success)
-        send_chain(:entry, circuit, time, success) do |e|
+      def entry(circuit, time, success, status)
+        send_chain(:entry, circuit, time, success, status) do |e|
           options.notifier.notify(:storage_failure, circuit: circuit, action: :entry, error: e)
         end
       end

--- a/lib/faulty/storage/fault_tolerant_proxy.rb
+++ b/lib/faulty/storage/fault_tolerant_proxy.rb
@@ -112,11 +112,11 @@ class Faulty
       # @see Interface#entry
       # @param (see Interface#entry)
       # @return (see Interface#entry)
-      def entry(circuit, time, success)
-        @storage.entry(circuit, time, success)
+      def entry(circuit, time, success, status)
+        @storage.entry(circuit, time, success, status)
       rescue StandardError => e
         options.notifier.notify(:storage_failure, circuit: circuit, action: :entry, error: e)
-        []
+        stub_status(circuit) if status
       end
 
       # Safely mark a circuit as open

--- a/lib/faulty/storage/interface.rb
+++ b/lib/faulty/storage/interface.rb
@@ -37,9 +37,10 @@ class Faulty
       # @param circuit [Circuit] The circuit that ran
       # @param time [Integer] The unix timestamp for the run
       # @param success [Boolean] True if the run succeeded
-      # @return [Array<Array>] An array of the new history tuples after adding
-      #   the new entry, see {#history}
-      def entry(circuit, time, success)
+      # @param status [Status, nil] The previous status. If given, this method must
+      #   return an updated status object from the new entry data.
+      # @return [Status, nil] If `status` is not nil, the updated status object.
+      def entry(circuit, time, success, status)
         raise NotImplementedError
       end
 

--- a/lib/faulty/storage/memory.rb
+++ b/lib/faulty/storage/memory.rb
@@ -99,13 +99,14 @@ class Faulty
       # @see Interface#entry
       # @param (see Interface#entry)
       # @return (see Interface#entry)
-      def entry(circuit, time, success)
+      def entry(circuit, time, success, status)
         memory = fetch(circuit)
         memory.runs.borrow do |runs|
           runs.push([time, success])
           runs.shift if runs.size > options.max_sample_size
         end
-        memory.runs.value
+
+        Status.from_entries(memory.runs.value, **status.to_h) if status
       end
 
       # Mark a circuit as open

--- a/lib/faulty/storage/null.rb
+++ b/lib/faulty/storage/null.rb
@@ -24,8 +24,8 @@ class Faulty
 
       # @param (see Interface#entry)
       # @return (see Interface#entry)
-      def entry(_circuit, _time, _success)
-        []
+      def entry(circuit, _time, _success, status)
+        stub_status(circuit) if status
       end
 
       # @param (see Interface#open)
@@ -64,10 +64,7 @@ class Faulty
       # @param (see Interface#status)
       # @return (see Interface#status)
       def status(circuit)
-        Faulty::Status.new(
-          options: circuit.options,
-          stub: true
-        )
+        stub_status(circuit)
       end
 
       # @param (see Interface#history)
@@ -88,6 +85,15 @@ class Faulty
       # @return (see Interface#fault_tolerant?)
       def fault_tolerant?
         true
+      end
+
+      private
+
+      def stub_status(circuit)
+        Faulty::Status.new(
+          options: circuit.options,
+          stub: true
+        )
       end
     end
   end

--- a/spec/storage/circuit_proxy_spec.rb
+++ b/spec/storage/circuit_proxy_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe Faulty::Storage::CircuitProxy do
     expect(notifier).not_to receive(:notify)
     backend = Faulty::Storage::Null.new
     proxy = described_class.new(backend, notifier: notifier)
-    proxy.entry(circuit, Faulty.current_time, true)
+    proxy.entry(circuit, Faulty.current_time, true, nil)
   end
 end

--- a/spec/storage/fault_tolerant_proxy_spec.rb
+++ b/spec/storage/fault_tolerant_proxy_spec.rb
@@ -21,16 +21,16 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
 
   it 'delegates to storage when adding entry succeeds' do
     described_class.new(inner_storage, notifier: notifier)
-      .entry(circuit, Faulty.current_time, true)
+      .entry(circuit, Faulty.current_time, true, nil)
     expect(inner_storage.history(circuit).size).to eq(1)
   end
 
-  it 'returns empty history when adding entry fails' do
+  it 'returns stub status when adding entry fails' do
     expect(notifier).to receive(:notify)
       .with(:storage_failure, circuit: circuit, action: :entry, error: instance_of(RuntimeError))
-    history = described_class.new(failing_storage, notifier: notifier)
-      .entry(circuit, Faulty.current_time, true)
-    expect(history).to eq([])
+    status = described_class.new(failing_storage, notifier: notifier)
+      .entry(circuit, Faulty.current_time, false, Faulty::Status.new(options: circuit.options))
+    expect(status.stub).to eq(true)
   end
 
   it 'returns stub status when getting #status' do

--- a/spec/storage/memory_spec.rb
+++ b/spec/storage/memory_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Faulty::Storage::Memory do
 
   it 'rotates entries after max_sample_size' do
     storage = described_class.new(max_sample_size: 3)
-    3.times { |i| storage.entry(circuit, i, true) }
+    3.times { |i| storage.entry(circuit, i, true, nil) }
     expect(storage.history(circuit).map { |h| h[0] }).to eq([0, 1, 2])
-    storage.entry(circuit, 9, true)
+    storage.entry(circuit, 9, true, nil)
     expect(storage.history(circuit).map { |h| h[0] }).to eq([1, 2, 9])
   end
 end

--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Faulty::Storage::Redis do
     subject(:storage) { described_class.new }
 
     it 'can add an entry' do
-      storage.entry(circuit, Faulty.current_time, true)
+      storage.entry(circuit, Faulty.current_time, true, nil)
       expect(storage.history(circuit).size).to eq(1)
     end
   end
@@ -29,7 +29,7 @@ RSpec.describe Faulty::Storage::Redis do
     end
 
     it 'adds an entry' do
-      storage.entry(circuit, Faulty.current_time, true)
+      storage.entry(circuit, Faulty.current_time, true, nil)
       expect(storage.history(circuit).size).to eq(1)
     end
 


### PR DESCRIPTION
The #entry method previously required history to be always returned.
This API had two problems:

- It is inefficient for cases when history is not required. There is no
  way to skip generating history when it is not needed. It is only
  needed when evaluating a failure, and for most (success) cases we can
  simply return nil.
- It prevents storage backends from implementing their own history
  scheme that does not store history in the standard way. For example,
  if we wanted a lossy storage mechanism, that would not be possible due
  to the need to return exact history.

Instead, we simply request storage backends to return status when it is
necessary. We do this by passing in the previous status. Storage
backends can then calculate the new status and return it when needed.

Benchmarks
----------------------

In MRI on Macbook Pro 2.6 GHz 6-Core Intel Core i7

### Previous

```
In memory circuits x100000
                                user     system      total        real
memory storage              1.799234   0.012232   1.811466 (  1.819888)
memory storage failures     3.559653   0.008567   3.568220 (  3.575123)
large memory storage        6.094560   0.061889   6.156449 (  6.169723)

Redis circuits x1000
                                user     system      total        real
redis storage               0.999390   0.087513   1.086903 (  1.114614)
redis storage failures      0.945950   0.078744   1.024694 (  1.046704)
large redis storage         5.085465   0.267473   5.352938 (  5.506144)


Extra x1000000
                                user     system      total        real
log listener success        0.540868   0.001510   0.542378 (  0.543516)
log listener failure        0.771250   0.001943   0.773193 (  0.775489)
```

### This PR

```
In memory circuits x100000
                                user     system      total        real
memory storage              1.428948   0.002122   1.431070 (  1.432266)
memory storage failures     3.441657   0.006171   3.447828 (  3.450833)
large memory storage        5.636445   0.011517   5.647962 (  5.660984)

Redis circuits x1000
                                user     system      total        real
redis storage               0.578602   0.063484   0.642086 (  0.652530)
redis storage failures      0.983572   0.079071   1.062643 (  1.089757)
large redis storage         2.708715   0.173754   2.882469 (  2.990413)


Extra x1000000
                                user     system      total        real
log listener success        0.532829   0.001563   0.534392 (  0.536336)
log listener failure        0.759030   0.001152   0.760182 (  0.761362)
```

So with the memory storage, large memory storage, redis storage, and large redis storage benchmarks, we see a 10% to 45% improvement in performance.

Deprecations
------------------------

- Storage::Interface#entry should now accept an additional parameter
  `status`. If given, the method must return the updated status,
  otherwise if status is `nil` #entry may return nil. Previously #entry
  always returned a history array. Backwards compatibility with older storage backends will be removed in 0.9