### PR TITLE
Fix crash in Redis storage backend if opened_at was missing

### DIFF
--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -94,4 +94,14 @@ RSpec.describe Faulty::Storage::Redis do
       expect { storage }.to output(/while checking client options: fail/).to_stderr
     end
   end
+
+  context 'when opened_at is missing and status is open' do
+    it 'sets opened_at to the maximum' do
+      Timecop.freeze
+      storage.open(circuit, Faulty.current_time)
+      client.del('faulty:circuit:test:opened_at')
+      status = storage.status(circuit)
+      expect(status.opened_at).to eq(Faulty.current_time - storage.options.circuit_ttl)
+    end
+  end
 end


### PR DESCRIPTION
If the circuit opened_at key was cleared or expired then the Redis
storage backend would crash. Fix this by setting the opened_at time to
its earliest-possible value.

Also change Redis backend to include opened_at in the transaction for
opening and closing circuits. This should reduce the chance that status
and opened_at get out of sync.
