### PR TITLE
Remove duplicate list_circuits method on Faulty class

### DIFF
--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -247,13 +247,6 @@ class Faulty
     @registry.retrieve(name, options, &block)
   end
 
-  # Get a list of all circuit names
-  #
-  # @return [Array<String>] The circuit names
-  def list_circuits
-    options.storage.list
-  end
-
   private
 
   # Get circuit options from the {Faulty} options


### PR DESCRIPTION
Thanks for this great gem! I noticed there is a duplicate method so this PR removes it.

https://github.com/ParentSquare/faulty/blob/6a0733f20f1a72e4ad1a095adf05b106e31be7cc/lib/faulty.rb#L116-L121