### PR TITLE
Add granular errors for Elasticsearch patch

### DIFF
--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -4,6 +4,7 @@ require 'securerandom'
 require 'forwardable'
 require 'concurrent'
 
+require 'faulty/deprecation'
 require 'faulty/immutable_options'
 require 'faulty/cache'
 require 'faulty/circuit'

--- a/lib/faulty/deprecation.rb
+++ b/lib/faulty/deprecation.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Faulty
+  # Support deprecating Faulty features
+  module Deprecation
+    class << self
+      # Call to raise errors instead of logging warnings for Faulty deprecations
+      def raise_errors!(enabled = true)
+        @raise_errors = (enabled == true)
+      end
+
+      def silenced
+        @silence = true
+        yield
+      ensure
+        @silence = false
+      end
+
+      # @private
+      def method(klass, name, note: nil, sunset: nil)
+        deprecate("#{klass}##{name}", note: note, sunset: sunset)
+      end
+
+      # @private
+      def deprecate(subject, note: nil, sunset: nil)
+        return if @silence
+
+        message = "#{subject} is deprecated"
+        message += " and will be removed in #{sunset}" if sunset
+        message += " (#{note})" if note
+        raise DeprecationError, message if @raise_errors
+
+        Kernel.warn("DEPRECATION: #{message}")
+      end
+    end
+  end
+end

--- a/lib/faulty/error.rb
+++ b/lib/faulty/error.rb
@@ -28,6 +28,9 @@ class Faulty
     end
   end
 
+  class DeprecationError < FaultyError
+  end
+
   # Included in faulty circuit errors to provide common features for
   # native and patched errors
   module CircuitErrorBase

--- a/lib/faulty/patch.rb
+++ b/lib/faulty/patch.rb
@@ -64,14 +64,15 @@ class Faulty
       #   option and these additional options
       # @option hash [String] :name The circuit name. Defaults to `default_name`
       # @option hash [Boolean] :patch_errors By default, circuit errors will be
-      #   subclasses of `options[:patched_error_module]`. The user can disable
+      #   subclasses of `options[:patched_error_mapper]`. The user can disable
       #   this by setting this option to false.
       # @option hash [Faulty, String, Symbol, Hash{ constant: String }] :instance
       #   A reference to a faulty instance. See examples.
       # @param options [Hash] Additional override options. Supports any circuit
       #   option and these additional ones.
-      # @option options [Module] :patched_error_module The namespace module
-      #   for patched errors
+      # @option options [Module] :patched_error_mapper The namespace module
+      #   for patched errors or a mapping proc. See {Faulty::Circuit::Options}
+      #   `:error_mapper`
       # @yield [Circuit::Options] For setting override options in a block
       # @return [Circuit, nil] The circuit if one was created
       def circuit_from_hash(default_name, hash, **options, &block)
@@ -80,8 +81,8 @@ class Faulty
         hash = symbolize_keys(hash)
         name = hash.delete(:name) || default_name
         patch_errors = hash.delete(:patch_errors) != false
-        error_module = options.delete(:patched_error_module)
-        hash[:error_module] ||= error_module if error_module && patch_errors
+        error_mapper = options.delete(:patched_error_mapper)
+        hash[:error_mapper] ||= error_mapper if error_mapper && patch_errors
         faulty = resolve_instance(hash.delete(:instance))
         faulty.circuit(name, **hash, **options, &block)
       end

--- a/lib/faulty/patch/mysql2.rb
+++ b/lib/faulty/patch/mysql2.rb
@@ -53,7 +53,7 @@ class Faulty
             ::Mysql2::Error::ConnectionError,
             ::Mysql2::Error::TimeoutError
           ],
-          patched_error_module: Faulty::Patch::Mysql2
+          patched_error_mapper: Faulty::Patch::Mysql2
         )
 
         super

--- a/lib/faulty/patch/redis.rb
+++ b/lib/faulty/patch/redis.rb
@@ -43,7 +43,7 @@ class Faulty
             ::Redis::BaseConnectionError,
             BusyError
           ],
-          patched_error_module: Faulty::Patch::Redis
+          patched_error_mapper: Faulty::Patch::Redis
         )
 
         super

--- a/spec/deprecation_spec.rb
+++ b/spec/deprecation_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Faulty::Deprecation do
+  it 'prints note and sunset version' do
+    expect(Kernel).to receive(:warn)
+      .with('DEPRECATION: foo is deprecated and will be removed in 1.0 (Use bar)')
+    described_class.deprecate(:foo, note: 'Use bar', sunset: '1.0')
+  end
+
+  it 'prints only subject' do
+    expect(Kernel).to receive(:warn)
+      .with('DEPRECATION: blah is deprecated')
+    described_class.deprecate('blah')
+  end
+
+  it 'prints method deprecation' do
+    expect(Kernel).to receive(:warn)
+      .with('DEPRECATION: Faulty::Circuit#foo is deprecated and will be removed in 1.0 (Use bar)')
+    described_class.method(Faulty::Circuit, :foo, note: 'Use bar', sunset: '1.0')
+  end
+
+  context 'with raise_errors!' do
+    before { described_class.raise_errors! }
+
+    after { described_class.raise_errors!(false) }
+
+    it 'raises DeprecationError' do
+      expect { described_class.deprecate('blah') }
+        .to raise_error(Faulty::DeprecationError, 'blah is deprecated')
+    end
+  end
+
+  context 'when silenced' do
+    it 'does not surface deprecations' do
+      expect(Kernel).not_to receive(:warn)
+      described_class.silenced do
+        described_class.deprecate('blah')
+      end
+    end
+  end
+end

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Faulty::Patch do
   describe '.circuit_from_hash' do
     let(:faulty) { Faulty.new(listeners: []) }
 
-    let(:error_module) do
+    let(:error_mapper) do
       stub_const('TestErrors', Module.new)
       described_class.define_circuit_errors(TestErrors, error_base)
       TestErrors
@@ -62,33 +62,33 @@ RSpec.describe Faulty::Patch do
     end
 
     context 'when patch_errors is enabled' do
-      it 'sets error_module' do
+      it 'sets error_mapper' do
         circuit = described_class.circuit_from_hash(
           'test',
           { instance: faulty },
-          patched_error_module: error_module
+          patched_error_mapper: error_mapper
         )
-        expect(circuit.options.error_module).to eq(error_module)
+        expect(circuit.options.error_mapper).to eq(error_mapper)
       end
     end
 
-    context 'when patch_errors is enabled but patched_error_module is missing' do
+    context 'when patch_errors is enabled but patched_error_mapper is missing' do
       it 'uses Faulty error module' do
         circuit = described_class.circuit_from_hash(
           'test',
           { instance: faulty, patch_errors: true }
         )
-        expect(circuit.options.error_module).to eq(Faulty)
+        expect(circuit.options.error_mapper).to eq(Faulty)
       end
     end
 
-    context 'when user sets error_module manually' do
-      it 'overrides patched_error_module' do
+    context 'when user sets error_mapper manually' do
+      it 'overrides patched_error_mapper' do
         circuit = described_class.circuit_from_hash(
           'test',
-          { instance: faulty, error_module: Faulty }
+          { instance: faulty, error_mapper: Faulty }
         )
-        expect(circuit.options.error_module).to eq(Faulty)
+        expect(circuit.options.error_mapper).to eq(Faulty)
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe Faulty::Patch do
           'test',
           { instance: faulty, patch_errors: false }
         )
-        expect(circuit.options.error_module).to eq(Faulty)
+        expect(circuit.options.error_mapper).to eq(Faulty)
       end
     end
 


### PR DESCRIPTION
With this change, the granular errors normally raised by Elasticsearch
will be preserved. Previously we were discarding the granular error
information raised by the Elasticsearch client and simply raising
an "Error" subclass. Now we raise a Faulty error which is always a
subclass of whichever error was raised by Elasticsearch itself.

To do this, we add support for procs in the new error_mapper option for
circuits. This allows us to individually map the errors returned by
Elasticsearch.

Add Faulty::Deprecation for deprecation notification

Deprecations
-----------------

- The error_module option is deprecated. Patches should use the error_module
  option instead. The option will be removed in 0.9