### PR TITLE
Define an inspect method that represent circuit

### DIFF
--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -158,9 +158,15 @@ class Faulty
 
     # @return [String] Text representation of the circuit
     def inspect
-      # rubocop:disable Layout/LineLength
-      interested_opts = %i[cache_expires_in cache_refreshes_after cache_refresh_jitter cool_down evaluation_window rate_threshold sample_threshold errors exclude]
-      # rubocop:enable Layout/LineLength
+      interested_opts = %i[
+        cache_expires_in
+        cache_refreshes_after
+        cache_refresh_jitter
+        cool_down evaluation_window
+        rate_threshold
+        sample_threshold
+        errors exclude
+      ]
       options_text = options.each_pair.map { |k, v| "#{k}: #{v}" if interested_opts.include?(k) }.compact.join(', ')
       %(#<#{self.class.name} name: #{name}, state: #{status.state}, options: { #{options_text} }>)
     end

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -156,6 +156,13 @@ class Faulty
       end
     end
 
+    # @return [String] Text representation of the circuit
+    def inspect
+      interested_opts = %i(cache_expires_in cache_refreshes_after cache_refresh_jitter cool_down evaluation_window rate_threshold sample_threshold errors exclude)
+      options_text = options.each_pair.map { |k,v| "#{k}: #{v}" if interested_opts.include?(k) }.compact.join(", ")
+      %(#<#{self.class.name} name: #{name}, state: #{status.state}, options: { #{options_text} }>)
+    end
+
     # @param name [String] The name of the circuit
     # @param options [Hash] Attributes for {Options}
     # @yield [Options] For setting options in a block

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -158,8 +158,10 @@ class Faulty
 
     # @return [String] Text representation of the circuit
     def inspect
-      interested_opts = %i(cache_expires_in cache_refreshes_after cache_refresh_jitter cool_down evaluation_window rate_threshold sample_threshold errors exclude)
-      options_text = options.each_pair.map { |k,v| "#{k}: #{v}" if interested_opts.include?(k) }.compact.join(", ")
+      # rubocop:disable Layout/LineLength
+      interested_opts = %i[cache_expires_in cache_refreshes_after cache_refresh_jitter cool_down evaluation_window rate_threshold sample_threshold errors exclude]
+      # rubocop:enable Layout/LineLength
+      options_text = options.each_pair.map { |k, v| "#{k}: #{v}" if interested_opts.include?(k) }.compact.join(', ')
       %(#<#{self.class.name} name: #{name}, state: #{status.state}, options: { #{options_text} }>)
     end
 

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -32,7 +32,9 @@ RSpec.context :circuits do
 
   it 'inspect' do
     circuit = Faulty::Circuit.new('plain')
+    # rubocop:disable Layout/LineLength
     expect(circuit.inspect).to eq '#<Faulty::Circuit name: plain, state: closed, options: { cache_expires_in: 86400, cache_refreshes_after: 900, cache_refresh_jitter: 180.0, cool_down: 300, evaluation_window: 60, rate_threshold: 0.5, sample_threshold: 3, errors: [StandardError], exclude: [] }>'
+    # rubocop:enable Layout/LineLength
   end
 
   it 'can be constructed with only a name' do

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -30,6 +30,11 @@ RSpec.context :circuits do
     TestErrors
   end
 
+  it 'inspect' do
+    circuit = Faulty::Circuit.new('plain')
+    expect(circuit.inspect).to eq '#<Faulty::Circuit name: plain, state: closed, options: { cache_expires_in: 86400, cache_refreshes_after: 900, cache_refresh_jitter: 180.0, cool_down: 300, evaluation_window: 60, rate_threshold: 0.5, sample_threshold: 3, errors: [StandardError], exclude: [] }>'
+  end
+
   it 'can be constructed with only a name' do
     circuit = Faulty::Circuit.new('plain')
     expect(circuit.name).to eq('plain')

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -32,9 +32,12 @@ RSpec.context :circuits do
 
   it 'inspect' do
     circuit = Faulty::Circuit.new('plain')
-    # rubocop:disable Layout/LineLength
-    expect(circuit.inspect).to eq '#<Faulty::Circuit name: plain, state: closed, options: { cache_expires_in: 86400, cache_refreshes_after: 900, cache_refresh_jitter: 180.0, cool_down: 300, evaluation_window: 60, rate_threshold: 0.5, sample_threshold: 3, errors: [StandardError], exclude: [] }>'
-    # rubocop:enable Layout/LineLength
+    expect(circuit.inspect).to eq(
+      '#<Faulty::Circuit name: plain, state: closed, options: { ' \
+      'cache_expires_in: 86400, cache_refreshes_after: 900, ' \
+      'cache_refresh_jitter: 180.0, cool_down: 300, evaluation_window: 60, ' \
+      'rate_threshold: 0.5, sample_threshold: 3, errors: [StandardError], exclude: [] }>'
+    )
   end
 
   it 'can be constructed with only a name' do


### PR DESCRIPTION
When I inspect the `circuit` in a console, it overwhelms the console with all the options (a solid few seconds to print all the things). 

How about we represent `Circuit` with a name, state and some circuit options?

Thanks!