### PR TITLE
Skip codacy coverage report for external contributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           MYSQL_USER: root
           MYSQL_PASSWORD: root
       - name: Run codacy-coverage-reporter
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: matrix.ruby == '2.7' && env.CODACY_PROJECT_TOKEN
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
Since the CODACY_PROJECT_TOKEN is not set