### PR TITLE
Use monotonic time if available

### DIFF
--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -15,6 +15,7 @@ require 'faulty/circuit_registry'
 require 'faulty/result'
 require 'faulty/status'
 require 'faulty/storage'
+require 'faulty/timer'
 
 # The {Faulty} class has class-level methods for global state or can be
 # instantiated to create an independent configuration.
@@ -127,9 +128,10 @@ class Faulty
     # Used by Faulty wherever the current time is needed. Can be overridden
     # for testing
     #
-    # @return [Time] The current time
+    # @return [Float] The current time
     def current_time
-      Time.now.to_i
+      @timer ||= Timer.new
+      @timer.current
     end
 
     # Disable Faulty circuits

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -547,7 +547,7 @@ class Faulty
     #
     # @return [Boolean] true if the cache should be refreshed
     def cache_should_refresh?(key)
-      time = options.cache.read(cache_refresh_key(key.to_s)).to_i
+      time = options.cache.read(cache_refresh_key(key.to_s)).to_f
       time + (((rand * 2) - 1) * options.cache_refresh_jitter) < Faulty.current_time
     end
 

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -232,7 +232,7 @@ class Faulty
         end
 
         state = futures[:state].value&.to_sym || :closed
-        opened_at = futures[:opened_at].value ? futures[:opened_at].value.to_i : nil
+        opened_at = futures[:opened_at].value ? futures[:opened_at].value.to_f : nil
         opened_at = Faulty.current_time - options.circuit_ttl if state == :open && opened_at.nil?
 
         Faulty::Status.from_entries(
@@ -356,7 +356,7 @@ class Faulty
       #
       # @return [Integer] The current block number
       def current_list_block
-        (Faulty.current_time.to_f / options.list_granularity).floor
+        (Faulty.current_time / options.list_granularity).floor
       end
 
       # Watch a Redis key and exec commands only if the key matches the expected
@@ -411,7 +411,7 @@ class Faulty
       def map_entries(raw_entries)
         raw_entries.map do |e|
           time, state = e.split(ENTRY_SEPARATOR)
-          [time.to_i, state == '1']
+          [time.to_f, state == '1']
         end
       end
 

--- a/lib/faulty/timer.rb
+++ b/lib/faulty/timer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal:true
+
+class Faulty
+  # The timer that Faulty uses to track relative times of circuit internals
+  class Timer
+    # Construct a new timer and save the offset from real time
+    def initialize
+      @offset = Time.now.to_f - Concurrent.monotonic_time
+    end
+
+    # Get the current monotonic time
+    #
+    # This is the system monotonic timer (if available) plus
+    # the relative offset fom realtime set when the timer was constructed.
+    #
+    # Since various systems could treat realtime and monotonic time differently,
+    # in a distributed environment, this can possibly lead to drift between
+    # different systems.
+    #
+    # @return [Float]
+    def current
+      @offset + Concurrent.monotonic_time
+    end
+  end
+end

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -116,7 +116,7 @@ RSpec.context :circuits do
       Timecop.freeze
       circuit.run { 'ok' }
       circuit.try_run { raise 'failed' }
-      expect(circuit.history).to eq([[Time.now.to_i, true], [Time.now.to_i, false]])
+      expect(circuit.history).to eq([[Time.now.to_f, true], [Time.now.to_f, false]])
     end
 
     it 'clears stats and history when reset' do

--- a/spec/faulty_spec.rb
+++ b/spec/faulty_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe Faulty do
 
   it 'gets the current timestamp' do
     Timecop.freeze(Time.new(2020, 1, 1, 0, 0, 0, '+00:00'))
-    expect(described_class.current_time).to eq(1_577_836_800)
+    expect(described_class.current_time).to eq(1_577_836_800.0)
+    expect(described_class.current_time).to be_a(Float)
   end
 
   it 'does not memoize circuits before they are run' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,12 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.warnings = false
 
+  config.before do
+    allow(Faulty).to receive(:current_time) do
+      Time.now.to_f
+    end
+  end
+
   config.after do
     Timecop.return
     Faulty.enable!


### PR DESCRIPTION
Faulty previously used the system time for circuit timestamps, this
could lead to inaccuracies in case the system time travelled forwards or
backwards. Use monotonic time if available to resolve those issues.