### PR TITLE
Change current_time to a float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,7 @@ of AutoWire.
 
 Initial public release
 
-[Unreleased]: https://github.com/ParentSquare/faulty/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/ParentSquare/faulty/compare/v0.8.7...HEAD
 [0.8.7]: https://github.com/ParentSquare/faulty/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/ParentSquare/faulty/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/ParentSquare/faulty/compare/v0.8.4...v0.8.5

--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -129,7 +129,7 @@ class Faulty
     #
     # @return [Time] The current time
     def current_time
-      Time.now.to_i
+      Time.now.to_f
     end
 
     # Disable Faulty circuits

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -232,7 +232,7 @@ class Faulty
         end
 
         state = futures[:state].value&.to_sym || :closed
-        opened_at = futures[:opened_at].value ? futures[:opened_at].value.to_i : nil
+        opened_at = futures[:opened_at].value ? Float(futures[:opened_at].value) : nil
         opened_at = Faulty.current_time - options.circuit_ttl if state == :open && opened_at.nil?
 
         Faulty::Status.from_entries(
@@ -356,7 +356,7 @@ class Faulty
       #
       # @return [Integer] The current block number
       def current_list_block
-        (Faulty.current_time.to_f / options.list_granularity).floor
+        (Faulty.current_time / options.list_granularity).floor
       end
 
       # Watch a Redis key and exec commands only if the key matches the expected
@@ -411,7 +411,7 @@ class Faulty
       def map_entries(raw_entries)
         raw_entries.map do |e|
           time, state = e.split(ENTRY_SEPARATOR)
-          [time.to_i, state == '1']
+          [Float(time), state == '1']
         end
       end
 

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -116,7 +116,7 @@ RSpec.context :circuits do
       Timecop.freeze
       circuit.run { 'ok' }
       circuit.try_run { raise 'failed' }
-      expect(circuit.history).to eq([[Time.now.to_i, true], [Time.now.to_i, false]])
+      expect(circuit.history).to eq([[Time.now.to_f, true], [Time.now.to_f, false]])
     end
 
     it 'clears stats and history when reset' do

--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -111,4 +111,12 @@ RSpec.describe Faulty::Storage::Redis do
       expect(status.opened_at).to eq(Faulty.current_time - storage.options.circuit_ttl)
     end
   end
+
+  context 'when history entries are integers and floats' do
+    it 'gets floats' do
+      client.lpush('faulty:circuit:test:entries', '1660865630:1')
+      client.lpush('faulty:circuit:test:entries', '1660865646.897674:1')
+      expect(storage.history(circuit)).to eq([[1_660_865_630.0, true], [1_660_865_646.897674, true]])
+    end
+  end
 end


### PR DESCRIPTION
Allows more precision when calculating circuit status if needed.

Benchmarks report no significant change to performance for in-memory or redis storage adapters.