### PR TITLE
Add Redis 5 support for patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
           - ruby: '2.7'
             redis: '4'
             search: ['opensearch-ruby:1.0.1', 'opensearchproject/opensearch:1.0.1']
+          # Elasticsearch 7.13
+          - ruby: '2.7'
+            redis: '4'
+            search: ['elasticsearch:7.13.3', 'elasticsearch:7.13.4']
           # Redis 5
-          # Will add support after fixing patch
-          # - ruby: '2.7'
-          #   redis: '5'
-          #   search: [['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']]
-          # Ruby 2.3 & Elasticsearch 7.13
+          - ruby: '2.7'
+            redis: '5'
+            search: ['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']
+          # Ruby 2.3 & Elasticsearch 7.5
           - ruby: '2.3'
             redis: '4'
             search: ['elasticsearch:7.5.0', 'elasticsearch:7.13.4']
@@ -68,7 +71,7 @@ jobs:
           MYSQL_USER: root
           MYSQL_PASSWORD: root
       - uses: codecov/codecov-action@v3
-        if: matrix.ruby == '2.7' && matrix.redis == '4'
+        if: matrix.ruby == '2.7'
         with:
           files: coverage/coverage.xml
 

--- a/README.md
+++ b/README.md
@@ -985,11 +985,12 @@ Mysql2::Client.new(host: '127.0.0.1', faulty: { instance: 'mysql2' })
 protects a Redis client with an internal circuit. Pass a `:faulty` key along
 with your connection options to enable the circuit breaker.
 
-The Redis patch supports the Redis gem versions 3 and 4.
+The Redis patch supports the Redis gem versions 3 and up
 
 ```ruby
 require 'faulty/patch/redis'
 
+# For Redis <= 4, pass faulty into the top-level connection options
 redis = Redis.new(url: 'redis://localhost:6379', faulty: {
   # The name for the redis circuit
   name: 'redis'
@@ -1004,6 +1005,12 @@ redis = Redis.new(url: 'redis://localhost:6379', faulty: {
   # will raise its default errors
   patch_errors: true
 })
+
+# Or for Redis 5+, pass faulty into the custom connection options
+redis = Redis.new(url: 'redis://localhost:6379', custom: { faulty: {
+  # ...
+}})
+
 redis.connect # raises Faulty::CircuitError if connection fails
 
 # If the faulty key is not given, no circuit is used

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -403,7 +403,7 @@ class Faulty
       cached_value
     end
 
-    # Excecute a run
+    # Execute a run
     #
     # @param cached_value The cached value if one is available
     # @param cache_key [String, nil] The cache key if one is given

--- a/lib/faulty/patch/redis.rb
+++ b/lib/faulty/patch/redis.rb
@@ -8,9 +8,12 @@ class Faulty
     #
     # This module is not required by default
     #
-    # Pass a `:faulty` key into your MySQL connection options to enable
+    # Redis <= 4
+    # ---------------------
+    # Pass a `:faulty` key into your Redis connection options to enable
     # circuit protection. See {Patch.circuit_from_hash} for the available
-    # options.
+    # options. On Redis 5+, the faulty key should be passed in the `:custom` hash
+    # instead of the top-level options. See example.
     #
     # By default, all circuit errors raised by this patch inherit from
     # `::Redis::BaseConnectionError`
@@ -18,7 +21,11 @@ class Faulty
     # @example
     #   require 'faulty/patch/redis'
     #
+    #   # Redis <= 4
     #   redis = Redis.new(url: 'redis://localhost:6379', faulty: {})
+    #   # Or for Redis 5+
+    #   redis = Redis.new(url: 'redis://localhost:6379', custom: { faulty: {} })
+    #
     #   redis.connect # raises Faulty::CircuitError if connection fails
     #
     #   # If the faulty key is not given, no circuit is used
@@ -27,72 +34,12 @@ class Faulty
     #
     # @see Patch.circuit_from_hash
     module Redis
-      include Base
-
-      Patch.define_circuit_errors(self, ::Redis::BaseConnectionError)
-
-      class BusyError < ::Redis::CommandError
-      end
-
-      # Patches Redis to add the `:faulty` key
-      def initialize(options = {})
-        @faulty_circuit = Patch.circuit_from_hash(
-          'redis',
-          options[:faulty],
-          errors: [
-            ::Redis::BaseConnectionError,
-            BusyError
-          ],
-          patched_error_mapper: Faulty::Patch::Redis
-        )
-
-        super
-      end
-
-      # The initial connection is protected by a circuit
-      def connect
-        faulty_run { super }
-      end
-
-      # Protect command calls
-      def call(command)
-        faulty_run { super }
-      end
-
-      # Protect command_loop calls
-      def call_loop(command, timeout = 0)
-        faulty_run { super }
-      end
-
-      # Protect pipelined commands
-      def call_pipelined(commands)
-        faulty_run { super }
-      end
-
-      # Inject specific error classes if client is patched
-      #
-      # This method does not raise errors, it returns them
-      # as exception objects, so we simply modify that error if necessary and
-      # return it.
-      #
-      # The call* methods above will then raise that error, so we are able to
-      # capture it with faulty_run.
-      def io(&block)
-        return super unless @faulty_circuit
-
-        reply = super
-        if reply.is_a?(::Redis::CommandError) && reply.message.start_with?('BUSY')
-          reply = BusyError.new(reply.message)
-        end
-
-        reply
-      end
     end
   end
 end
 
-class Redis
-  class Client
-    prepend(Faulty::Patch::Redis)
-  end
+if Redis::VERSION.to_f < 5
+  require 'faulty/patch/redis/patch'
+else
+  require 'faulty/patch/redis/middleware'
 end

--- a/lib/faulty/patch/redis/middleware.rb
+++ b/lib/faulty/patch/redis/middleware.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Faulty
+  module Patch
+    module Redis
+      Patch.define_circuit_errors(self, ::RedisClient::ConnectionError)
+
+      class BusyError < ::RedisClient::CommandError
+      end
+
+      module Middleware
+        include Base
+
+        def initialize(client)
+          @faulty_circuit = Patch.circuit_from_hash(
+            'redis',
+            client.config.custom[:faulty],
+            errors: [
+              ::RedisClient::ConnectionError,
+              BusyError
+            ],
+            patched_error_mapper: Faulty::Patch::Redis
+          )
+
+          super
+        end
+
+        def connect(redis_config)
+          faulty_run { super }
+        end
+
+        def call(commands, redis_config)
+          faulty_run { wrap_command { super } }
+        end
+
+        def call_pipelined(commands, redis_config)
+          faulty_run { wrap_command { super } }
+        end
+
+        private
+
+        def wrap_command
+          yield
+        rescue ::RedisClient::CommandError => e
+          raise BusyError, e.message if e.message.start_with?('BUSY')
+
+          raise
+        end
+      end
+
+      ::RedisClient.register(Middleware)
+    end
+  end
+end

--- a/lib/faulty/patch/redis/patch.rb
+++ b/lib/faulty/patch/redis/patch.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'redis'
+
+class Faulty
+  module Patch
+    module Redis
+      include Base
+
+      Patch.define_circuit_errors(self, ::Redis::BaseConnectionError)
+
+      class BusyError < ::Redis::CommandError
+      end
+
+      # Patches Redis to add the `:faulty` key
+      def initialize(options = {})
+        @faulty_circuit = Patch.circuit_from_hash(
+          'redis',
+          options[:faulty],
+          errors: [
+            ::Redis::BaseConnectionError,
+            BusyError
+          ],
+          patched_error_mapper: Faulty::Patch::Redis
+        )
+
+        super
+      end
+
+      # The initial connection is protected by a circuit
+      def connect
+        faulty_run { super }
+      end
+
+      # Protect command calls
+      def call(command)
+        faulty_run { super }
+      end
+
+      # Protect command_loop calls
+      def call_loop(command, timeout = 0)
+        faulty_run { super }
+      end
+
+      # Protect pipelined commands
+      def call_pipelined(commands)
+        faulty_run { super }
+      end
+
+      # Inject specific error classes if client is patched
+      #
+      # This method does not raise errors, it returns them
+      # as exception objects, so we simply modify that error if necessary and
+      # return it.
+      #
+      # The call* methods above will then raise that error, so we are able to
+      # capture it with faulty_run.
+      def io(&block)
+        return super unless @faulty_circuit
+
+        reply = super
+        if reply.is_a?(::Redis::CommandError) && reply.message.start_with?('BUSY')
+          reply = BusyError.new(reply.message)
+        end
+
+        reply
+      end
+    end
+  end
+end
+
+class Redis
+  class Client
+    prepend(Faulty::Patch::Redis)
+  end
+end


### PR DESCRIPTION
Adds support for redis gem version 5 in the redis patch. Using this patch with Redis 5 will require changing how faulty is specified for Redis connections, so this updates the documentation as well to reflect those different configuration mechanisms.