### PR TITLE
Reserve half-open tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.yardoc/
 
 .byebug_history
+
+/.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 -------------------
 
+[0.13.0] - 2026-05-13
+---------------------
+
+### Added
+
+* Reserve half-open test runs across processes so only one process executes
+  the test block when a circuit becomes half-open. justinhoward
+
+### Changed
+
+* `Faulty::Status` now captures `current_time` once when the status is built,
+  so all predicates (`open?`, `half_open?`, `reserved?`) reason about the same
+  point in time. Previously each predicate called `Faulty.current_time`
+  independently. justinhoward
+* `Storage::Redis#close` now also clears the `reserved_at` key. justinhoward
+
+### Fixed
+
+* `Storage::Redis#reserve` uses safe navigation when serializing
+  `previous_reserved_at` for `WATCH`, so the very first CAS against a missing
+  key compares correctly. justinhoward
+* `Storage::Redis#reset` now clears the `reserved_at` key. justinhoward
+* `Status#can_run?` now treats `locked_closed?` as an unconditional override,
+  so a manually locked-closed circuit runs even when a half-open reservation
+  is still in effect from a prior cycle. justinhoward
+
+### Breaking Changes
+
+* `Storage::Interface` adds a required `#reserve(circuit, reserved_at,
+  previous_reserved_at)` method. Custom storage backends must implement it,
+  and the `Status` value object must carry the new `reserved_at` attribute.
+  See `Storage::Interface#reserve` for the contract and the conformance
+  test in `spec/storage/interface_spec.rb` for the structural guarantee.
+
 [0.12.0] - 2026-05-13
 ---------------------
 
@@ -349,7 +383,9 @@ of AutoWire.
 
 Initial public release
 
-[Unreleased]: https://github.com/ParentSquare/faulty/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/ParentSquare/faulty/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/ParentSquare/faulty/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/ParentSquare/faulty/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/ParentSquare/faulty/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/ParentSquare/faulty/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/ParentSquare/faulty/compare/v0.8.7...v0.9.0

--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,23 @@ state, Faulty allows a single execution of the block as a test run. If the test
 run succeeds, the circuit is fully closed and the circuit state is reset. If the
 test run fails, the circuit is opened and the cool-down is reset.
 
+When the storage backend supports atomic operations (the default `Memory` and
+`Redis` backends both do), the half-open test run is reserved exclusively. Other
+processes or threads that observe the half-open state while a test run is in
+progress will be skipped with `Faulty::OpenCircuitError`, just as if the circuit
+were still open. The reservation expires after `cool_down` so that a crashed
+process can't permanently wedge the circuit.
+
+This means `cool_down` does double duty: it gates how long the circuit waits
+before retrying after opening, and it bounds how long a half-open reservation
+is honored. Test runs that legitimately take longer than `cool_down` (for
+example, a slow downstream during recovery) will see their reservation expire
+mid-run, at which point another process can reserve and run the block
+concurrently. If your protected calls can run longer than `cool_down`, set
+`cool_down` to comfortably exceed the slowest expected latency for the
+protected operation, or accept that occasional duplicate half-open test runs
+are possible during slow recoveries.
+
 Each time the circuit changes state or executes the block, events are raised
 that are sent to the Faulty event notifier. The notifier should be used to track
 circuit failure rates, open circuits, etc.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# Dev-only stack for spec dependencies. All services run with auth disabled
+# or default credentials, so ports are bound to 127.0.0.1 to keep them off
+# any other network interface.
+services:
+  mysql:
+    image: mysql:8.0.31
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+    ports:
+      - "127.0.0.1:3306:3306"
+
+  redis:
+    image: redis:6.2
+    entrypoint: redis-server --appendonly yes
+    ports:
+      - "127.0.0.1:6379:6379"
+
+  opensearch:
+    image: opensearchproject/opensearch:2.7.0
+    environment:
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+    ports:
+      - "127.0.0.1:9200:9200"

--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -125,9 +125,11 @@ class Faulty
     # The current time
     #
     # Used by Faulty wherever the current time is needed. Can be overridden
-    # for testing
+    # for testing. Returned as a Float (Unix epoch seconds with sub-second
+    # precision) so it can be stored in numeric Redis fields and compared
+    # against other timestamps without conversion.
     #
-    # @return [Time] The current time
+    # @return [Float] The current time as a Unix timestamp
     def current_time
       Time.now.to_f
     end

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -49,6 +49,10 @@ class Faulty
     # @!attribute [r] cool_down
     #   @return [Integer] The number of seconds the circuit will
     #     stay open after it is tripped. Default 300.
+    #
+    #     Also bounds the half-open reservation TTL — runs longer than
+    #     `cool_down` lose exclusivity. See the "How it Works" section
+    #     of the README.
     # @!attribute [r] error_mapper
     #   @return [Module, #call] Used by patches to set the namespace module for
     #     the faulty errors that will be raised. Should be a module or a callable.
@@ -308,9 +312,11 @@ class Faulty
       return cached_value if !cached_value.nil? && !cache_should_refresh?(cache)
 
       current_status = status
-      return run_skipped(cached_value) unless current_status.can_run?
-
-      run_exec(current_status, cached_value, cache, &block)
+      if current_status.can_run? && reserve(current_status)
+        run_exec(current_status, cached_value, cache, &block)
+      else
+        run_skipped(cached_value)
+      end
     end
 
     # Force the circuit to stay open until unlocked
@@ -401,6 +407,32 @@ class Faulty
       raise map_error(:OpenCircuitError) if cached_value.nil?
 
       cached_value
+    end
+
+    # Reserves execution for this circuit when it is half-open
+    #
+    # This prevents concurrent evaluation from allowing multiple simultaneous
+    # runs for half-open circuits. For non-half-open states this is a no-op
+    # that returns true so closed and locked-closed circuits run unconditionally.
+    #
+    # `locked_closed?` is checked before `half_open?` to mirror the operator-
+    # override hierarchy in {Status#can_run?}: a locked-closed circuit must
+    # always proceed regardless of the underlying state, even if another
+    # process is currently holding the reservation. Without this, a locked-
+    # closed circuit could lose the storage CAS to a concurrent process and
+    # be incorrectly skipped.
+    #
+    # @param status [Status] The current status of the circuit
+    # @return [Boolean] True if this call may proceed to execute the block
+    def reserve(status)
+      return true if status.locked_closed?
+      return true unless status.half_open?
+
+      # Persist a fresh Faulty.current_time, not status.current_time. The
+      # snapshot exists for predicate consistency (see Status#current_time);
+      # the stored reserved_at should reflect when the reservation was made,
+      # not when the snapshot was taken.
+      storage.reserve(self, Faulty.current_time, status.reserved_at)
     end
 
     # Execute a run

--- a/lib/faulty/status.rb
+++ b/lib/faulty/status.rb
@@ -16,9 +16,19 @@ class Faulty
   #   @return [:open, :closed, nil] If the circuit is locked, the state that
   #     it is locked in. Default `nil`.
   # @!attribute [r] opened_at
-  #   @return [Integer, nil] If the circuit is open, the timestamp that it was
-  #     opened. This is not necessarily reset when the circuit is closed.
-  #     Default `nil`.
+  #   @return [Float, nil] If the circuit is open, the timestamp ({Faulty.current_time})
+  #     that it was opened. This is not necessarily reset when the circuit
+  #     is closed. Default `nil`.
+  # @!attribute [r] reserved_at
+  #   @return [Float, nil] If a half-open test run was reserved, the
+  #     timestamp ({Faulty.current_time}) of that reservation. Cleared when
+  #     the circuit is closed.
+  #     Not reset by {Storage::Interface#reopen}; the value naturally expires
+  #     via `cool_down`. Default `nil`.
+  #
+  #     Only meaningful when {#state} is `:open`. If a backend race or bug
+  #     produces an inconsistent shape (`state == :closed` with a non-nil
+  #     `reserved_at`), it is normalized to `nil` at construction.
   # @!attribute [r] failure_rate
   #   @return [Float] A number from 0 to 1 representing the percentage of
   #     failures for the circuit. For exmaple 0.5 represents a 50% failure rate.
@@ -34,6 +44,7 @@ class Faulty
     :state,
     :lock,
     :opened_at,
+    :reserved_at,
     :failure_rate,
     :sample_size,
     :options,
@@ -42,6 +53,19 @@ class Faulty
 
   class Status
     include ImmutableOptions
+
+    # @return [Float] The point in time captured when this status was built.
+    #   All predicates (`open?`, `half_open?`, `reserved?`) reason about
+    #   this same instant so they are mutually consistent. Held as an
+    #   instance variable rather than a struct field so it does not leak
+    #   into `to_h`, `==`, or `members` — those should reflect persisted
+    #   circuit state, not a transient predicate-consistency snapshot.
+    attr_reader :current_time
+
+    def initialize(hash, &)
+      @current_time = hash[:current_time] || Faulty.current_time
+      super(hash.except(:current_time), &)
+    end
 
     # The allowed state values
     STATES = %i[
@@ -66,7 +90,8 @@ class Faulty
     #   sample_size
     # @return [Status]
     def self.from_entries(entries, **hash)
-      window_start = Faulty.current_time - hash[:options].evaluation_window
+      current_time = Faulty.current_time
+      window_start = current_time - hash[:options].evaluation_window
       size = entries.size
       i = 0
       failures = 0
@@ -84,7 +109,8 @@ class Faulty
 
       new(hash.merge(
         sample_size: sample_size,
-        failure_rate: sample_size.zero? ? 0.0 : failures.to_f / sample_size
+        failure_rate: sample_size.zero? ? 0.0 : failures.to_f / sample_size,
+        current_time: current_time
       ))
     end
 
@@ -94,7 +120,7 @@ class Faulty
     #
     # @return [Boolean] True if open
     def open?
-      state == :open && opened_at + options.cool_down > Faulty.current_time
+      state == :open && opened_at + options.cool_down > current_time
     end
 
     # Whether the circuit is closed
@@ -112,7 +138,7 @@ class Faulty
     #
     # @return [Boolean] True if half-open
     def half_open?
-      state == :open && opened_at + options.cool_down <= Faulty.current_time
+      state == :open && opened_at + options.cool_down <= current_time
     end
 
     # Whether the circuit is locked open
@@ -129,15 +155,42 @@ class Faulty
       lock == :closed
     end
 
+    # Whether a half-open test run is currently reserved
+    #
+    # Process-agnostic: returns true whenever an unexpired reservation exists
+    # on this circuit, regardless of who made it. The "did someone else reserve
+    # this?" interpretation only applies when this predicate is read on a
+    # status snapshot taken *before* the caller attempts {Storage::Interface#reserve};
+    # a caller introspecting their own status after a successful reserve will
+    # also see `true` here.
+    #
+    # The reservation expires after `cool_down` to handle the case where the
+    # process that made the reservation crashes before resolving the circuit.
+    # Side effect: a legitimately-slow test run that exceeds `cool_down`
+    # loses exclusivity (another process may reserve and run concurrently).
+    # See the "How it Works" section of the README for the full trade-off.
+    #
+    # @return [Boolean] True if a reservation is in effect
+    def reserved?
+      return false unless reserved_at
+
+      state == :open && reserved_at + options.cool_down > current_time
+    end
+
     # Whether the circuit can be run
     #
-    # Takes the circuit state, locks and cooldown into account
+    # Takes the circuit state, locks and cooldown into account. Locks are
+    # operator overrides and take precedence over both state and reservation,
+    # so a `locked_closed?` circuit always runs and a `locked_open?` circuit
+    # never runs.
     #
     # @return [Boolean] True if the circuit can be run
     def can_run?
       return false if locked_open?
+      return true if locked_closed?
+      return false if reserved?
 
-      closed? || locked_closed? || half_open?
+      closed? || half_open?
     end
 
     # Whether the circuit fails the sample size and rate thresholds
@@ -155,6 +208,14 @@ class Faulty
         raise ArgumentError, "lock must be a symbol in #{self.class}::LOCKS or nil"
       end
       raise ArgumentError, 'opened_at is required if state is open' if state == :open && opened_at.nil?
+
+      # `reserved_at` is only meaningful while the circuit is open. Backends
+      # are expected to clear it on close, but if a brief race or backend bug
+      # leaves a stale value paired with `state == :closed`, normalize it
+      # here so downstream code can rely on the invariant without checking
+      # `state` first. Sanitizing rather than raising avoids turning a
+      # transient backend inconsistency into a production crash.
+      self.reserved_at = nil if state == :closed && !reserved_at.nil?
     end
 
     def required

--- a/lib/faulty/storage/circuit_proxy.rb
+++ b/lib/faulty/storage/circuit_proxy.rb
@@ -52,6 +52,7 @@ class Faulty
         open
         reopen
         close
+        reserve
         lock
         unlock
         reset

--- a/lib/faulty/storage/fallback_chain.rb
+++ b/lib/faulty/storage/fallback_chain.rb
@@ -105,6 +105,16 @@ class Faulty
         end
       end
 
+      # Reserve a half-open run in the first available storage backend
+      #
+      # @param (see Interface#reserve)
+      # @return (see Interface#reserve)
+      def reserve(circuit, reserved_at, previous_reserved_at)
+        send_chain(:reserve, circuit, reserved_at, previous_reserved_at) do |e|
+          options.notifier.notify(:storage_failure, circuit: circuit, action: :reserve, error: e)
+        end
+      end
+
       # Lock a circuit in all storage backends
       #
       # @param (see Interface#lock)

--- a/lib/faulty/storage/fault_tolerant_proxy.rb
+++ b/lib/faulty/storage/fault_tolerant_proxy.rb
@@ -9,6 +9,19 @@ class Faulty
     #
     # If the storage backend raises a `StandardError`, it will be captured and
     # sent to the notifier.
+    #
+    # The overall design preference is to keep protected code paths running
+    # when the storage backend is degraded, even when that means losing
+    # circuit-breaker protections that the storage normally provides:
+    # `#status` returns a stub closed status (so `Circuit#run` proceeds),
+    # `#reserve` returns `true` (so half-open test runs proceed), and the
+    # write paths (`#open`, `#reopen`, `#close`, `#entry`) return `false`
+    # to safe-deny the *recorded transition* without failing the in-flight
+    # call. The trade-off is that a correlated outage of the storage
+    # backend and the upstream protected by the circuit will let the fleet
+    # converge on the upstream — but that fleet would converge anyway via
+    # the stub-closed status path, so individual write methods don't make
+    # it worse.
     class FaultTolerantProxy
       extend Forwardable
 
@@ -175,6 +188,22 @@ class Faulty
       rescue StandardError => e
         options.notifier.notify(:storage_failure, circuit: circuit, action: :status, error: e)
         stub_status(circuit)
+      end
+
+      # Safely reserve execution of a circuit
+      #
+      # Returns `true` on storage error so half-open test runs proceed when
+      # the backend is degraded. See the class-level docs for the gem's
+      # fail-open trade-off.
+      #
+      # @see Interface#reserve
+      # @param (see Interface#reserve)
+      # @return (see Interface#reserve)
+      def reserve(circuit, reserved_at, previous_reserved_at)
+        @storage.reserve(circuit, reserved_at, previous_reserved_at)
+      rescue StandardError => e
+        options.notifier.notify(:storage_failure, circuit: circuit, action: :reserve, error: e)
+        true
       end
 
       # This cache makes any storage fault tolerant, so this is always `true`

--- a/lib/faulty/storage/interface.rb
+++ b/lib/faulty/storage/interface.rb
@@ -35,7 +35,8 @@ class Faulty
       # long as it can implement the other read methods.
       #
       # @param circuit [Circuit] The circuit that ran
-      # @param time [Integer] The unix timestamp for the run
+      # @param time [Float] The unix timestamp for the run, from
+      #   {Faulty.current_time}
       # @param success [Boolean] True if the run succeeded
       # @param status [Status, nil] The previous status. If given, this method must
       #   return an updated status object from the new entry data.
@@ -58,7 +59,8 @@ class Faulty
       # current time.
       #
       # @param circuit [Circuit] The circuit to open
-      # @param opened_at [Integer] The timestmp the circuit was opened at
+      # @param opened_at [Float] The timestamp the circuit was opened at,
+      #   from {Faulty.current_time}
       # @return [Boolean] True if the circuit transitioned from closed to open
       def open(circuit, opened_at)
         raise NotImplementedError
@@ -75,10 +77,35 @@ class Faulty
       # it may always return true, but that could result in duplicate reopen
       # notifications.
       #
+      # The backend MUST NOT clear `reserved_at` here.
+      #
+      # Preserving the prior cycle's `reserved_at` is load-bearing for
+      # half-open exclusivity. If a late-arriving caller read status while
+      # `reserved_at` was still nil (before the winning process reserved),
+      # its subsequent `reserve(circuit, T, nil)` CAS must fail. Clearing
+      # `reserved_at` in `reopen` would let that stale CAS incorrectly
+      # succeed and produce a duplicate half-open run.
+      #
+      # Beyond exclusivity, the prior reservation expires naturally at
+      # `reserved_at + cool_down`, aligned with the start of the next
+      # half-open window (since `reserved_at <= new_opened_at`). An
+      # explicit reset would be redundant with the cool-down-aligned expiry
+      # that already handles crash recovery.
+      #
+      # This invariant assumes the reservation TTL equals `cool_down`. If
+      # a separate `reservation_ttl` is ever introduced, this method must
+      # be revisited and may need to clear `reserved_at` explicitly.
+      #
       # @param circuit [Circuit] The circuit to reopen
-      # @param opened_at [Integer] The timestmp the circuit was opened at
-      # @param previous_opened_at [Integer] The last known value of opened_at.
-      #   Can be used to comare-and-set.
+      # @param opened_at [Float] The timestamp the circuit was opened at,
+      #   from {Faulty.current_time}
+      # @param previous_opened_at [Float] The last known value of opened_at.
+      #   Can be used to compare-and-set. Always non-nil — `Circuit#failure!`
+      #   only enters the reopen branch when `status.half_open?` is true,
+      #   which requires non-nil `opened_at`. Unlike `previous_reserved_at`
+      #   on {#reserve}, there is no legitimate "no prior value" call path
+      #   to `reopen`, so backends may treat this parameter as required and
+      #   are not expected to handle `nil`.
       # @return [Boolean] True if the opened_at time was updated
       def reopen(circuit, opened_at, previous_opened_at)
         raise NotImplementedError
@@ -90,12 +117,45 @@ class Faulty
       # may be called more than once. If so, this method should return true
       # only once, when the circuit transitions from open to closed.
       #
+      # The backend should reset the reserved_at value to empty when closing
+      # the circuit.
+      #
       # If the backend does not support locking or atomic operations, then
       # it may always return true, but that could result in duplicate close
       # notifications.
       #
       # @return [Boolean] True if the circuit transitioned from open to closed
       def close(circuit)
+        raise NotImplementedError
+      end
+
+      # Reserve an exclusive run for this circuit
+      #
+      # This is used when the circuit is half-open and the test run is being
+      # attempted. We need to make sure only a single run is allowed.
+      #
+      # The backend should store reserved_at and use it to serve future status
+      # requests. When setting reserved_at, the backend should atomically
+      # compare any existing value using previous_reserved_at. This ensures
+      # that mutltiple parallel processes can't reserve the circuit.
+      #
+      # The return value is the caller's signal to proceed with the half-open
+      # test run, not a strict report of whether atomic acquisition succeeded.
+      # Atomic backends should return `true` only when the CAS against
+      # `previous_reserved_at` succeeds. Non-atomic backends, no-op backends
+      # ({Null}), or wrappers that fail open ({FaultTolerantProxy}) may always
+      # return `true`; the caller will proceed at the cost of allowing
+      # duplicate half-open test runs.
+      #
+      # @param circuit [Circuit] The circuit to reserve
+      # @param reserved_at [Float] The timestamp of this reservation, from
+      #   {Faulty.current_time}
+      # @param previous_reserved_at [Float, nil] The last known value of
+      #   reserved_at, or nil for the first reservation in a new open cycle.
+      #   Can be used to compare-and-set.
+      # @return [Boolean] True if the caller may proceed with the half-open
+      #   test run; false if another caller already holds the reservation.
+      def reserve(circuit, reserved_at, previous_reserved_at)
         raise NotImplementedError
       end
 

--- a/lib/faulty/storage/null.rb
+++ b/lib/faulty/storage/null.rb
@@ -46,6 +46,12 @@ class Faulty
         true
       end
 
+      # @param (see Interface#reserve)
+      # @return (see Interface#reserve)
+      def reserve(_circuit, _reserved_at, _previous_reserved_at)
+        true
+      end
+
       # @param (see Interface#lock)
       # @return (see Interface#lock)
       def lock(_circuit, _state)

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -174,8 +174,22 @@ class Faulty
         result = watch_exec(key, ['open']) do |m|
           m.set(key, 'closed', ex: ex)
           m.del(entries_key(circuit.name))
+          m.del(reserved_at_key(circuit.name))
         end
 
+        result && result[0] == 'OK'
+      end
+
+      # Reserve an exclusive run for this circuit
+      #
+      # @see Interface#reserve
+      # @param (see Interface#reserve)
+      # @return (see Interface#reserve)
+      def reserve(circuit, reserved_at, previous_reserved_at)
+        key = reserved_at_key(circuit.name)
+        result = watch_exec(key, [previous_reserved_at&.to_s]) do |m|
+          m.set(key, reserved_at, ex: options.circuit_ttl)
+        end
         result && result[0] == 'OK'
       end
 
@@ -210,6 +224,7 @@ class Faulty
           r.del(
             entries_key(name),
             opened_at_key(name),
+            reserved_at_key(name),
             lock_key(name),
             options_key(name)
           )
@@ -228,20 +243,11 @@ class Faulty
           futures[:state] = r.get(state_key(circuit.name))
           futures[:lock] = r.get(lock_key(circuit.name))
           futures[:opened_at] = r.get(opened_at_key(circuit.name))
+          futures[:reserved_at] = r.get(reserved_at_key(circuit.name))
           futures[:entries] = r.lrange(entries_key(circuit.name), 0, -1)
         end
 
-        state = futures[:state].value&.to_sym || :closed
-        opened_at = futures[:opened_at].value ? Float(futures[:opened_at].value) : nil
-        opened_at = Faulty.current_time - options.circuit_ttl if state == :open && opened_at.nil?
-
-        Faulty::Status.from_entries(
-          map_entries(futures[:entries].value),
-          state: state,
-          lock: futures[:lock].value&.to_sym,
-          opened_at: opened_at,
-          options: circuit.options
-        )
+        build_status(circuit, futures)
       end
 
       # Get the circuit history up to `max_sample_size`
@@ -285,6 +291,26 @@ class Faulty
 
       private
 
+      # Build a {Status} from the redis values fetched by {#status}
+      def build_status(circuit, futures)
+        state = futures[:state].value&.to_sym || :closed
+        opened_at = parse_float(futures[:opened_at].value)
+        opened_at = Faulty.current_time - options.circuit_ttl if state == :open && opened_at.nil?
+
+        Faulty::Status.from_entries(
+          map_entries(futures[:entries].value),
+          state: state,
+          lock: futures[:lock].value&.to_sym,
+          opened_at: opened_at,
+          reserved_at: parse_float(futures[:reserved_at].value),
+          options: circuit.options
+        )
+      end
+
+      def parse_float(value)
+        value ? Float(value) : nil
+      end
+
       # Generate a key from its parts
       #
       # @return [String] The key
@@ -319,6 +345,11 @@ class Faulty
       # @return [String] The key for circuit opened_at
       def opened_at_key(circuit_name)
         ckey(circuit_name, 'opened_at')
+      end
+
+      # @return [String] The key for circuit reserved_at
+      def reserved_at_key(circuit_name)
+        ckey(circuit_name, 'reserved_at')
       end
 
       # Get the current key to add circuit names to

--- a/lib/faulty/version.rb
+++ b/lib/faulty/version.rb
@@ -3,6 +3,6 @@
 class Faulty
   # The current Faulty version
   def self.version
-    Gem::Version.new('0.12.0')
+    Gem::Version.new('0.13.0')
   end
 end

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -100,6 +100,26 @@ RSpec.context :circuits do
       expect(open_circuit.run { 'ok' }).to eq('ok')
     end
 
+    it 'ignores an active reservation when locked closed' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      storage.reserve(open_circuit, Faulty.current_time, nil)
+      open_circuit.lock_closed!
+
+      expect(open_circuit.run { 'ok' }).to eq('ok')
+    end
+
+    it 'still runs when locked closed even if storage reservation would fail' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      open_circuit.lock_closed!
+
+      allow(storage).to receive(:reserve).and_return(false)
+
+      expect(open_circuit.run { 'ok' }).to eq('ok')
+      expect(storage).not_to have_received(:reserve)
+    end
+
     it 'can be unlocked from the locked_open state' do
       circuit.lock_open!
       circuit.unlock!
@@ -166,6 +186,95 @@ RSpec.context :circuits do
       result = open_circuit.run { 'ok' }
       expect(result).to eq('ok')
       expect(open_circuit.status.closed?).to be(true)
+    end
+
+    it 'prevents concurrent circuit executions while half-open' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      expect(open_circuit.status.half_open?).to be(true)
+
+      block_runs = Concurrent::AtomicFixnum.new(0)
+      sync = Concurrent::CyclicBarrier.new(2)
+
+      winner = Thread.new do
+        open_circuit.try_run do
+          block_runs.increment
+          sync.wait(3) || raise('timeout waiting for loser to start')
+          sync.wait(3) || raise('timeout waiting for loser to finish')
+          'ok'
+        end
+      end
+
+      loser = Thread.new do
+        sync.wait(3) || raise('timeout waiting for winner to reserve')
+        result = open_circuit.try_run do
+          block_runs.increment
+          'unexpected'
+        end
+        sync.wait(3) || raise('timeout signaling winner')
+        result
+      end
+
+      winner_result = winner.value
+      loser_result = loser.value
+
+      expect(block_runs.value).to eq(1)
+      expect(loser_result.error?).to be(true)
+      expect(loser_result.error).to be_a(Faulty::OpenCircuitError)
+      expect(winner_result.ok?).to be(true)
+      expect(winner_result.get).to eq('ok')
+      expect(open_circuit.status.closed?).to be(true)
+      expect(open_circuit.status.reserved_at).to be_nil
+    end
+
+    it 'resets half-open reservation after cool-down period' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      expect(open_circuit.status.half_open?).to be(true)
+
+      expect(storage.reserve(open_circuit, Faulty.current_time, nil)).to be(true)
+      expect(open_circuit.status.can_run?).to be(false)
+
+      Timecop.freeze(Time.now + 301)
+      expect(open_circuit.status.can_run?).to be(true)
+    end
+
+    # Storage#reopen MUST NOT clear reserved_at. The prior cycle's
+    # reservation expires naturally at opened_at_new + cool_down, which is
+    # exactly when the next half-open window opens, so the previous value is
+    # the correct WATCH baseline for the next cycle's CAS.
+    it 'allows a fresh reservation on the second half-open cycle after a failure' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      open_circuit.try_run { raise 'fail in half-open' }
+      expect(open_circuit.status.open?).to be(true)
+
+      Timecop.freeze(Time.now + 300)
+      expect(open_circuit.status.half_open?).to be(true)
+      expect(open_circuit.status.reserved?).to be(false)
+      expect(open_circuit.run { 'ok' }).to eq('ok')
+      expect(open_circuit.status.closed?).to be(true)
+    end
+
+    it 'clears reserved_at when a successful half-open run closes the circuit' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      expect(open_circuit.status.half_open?).to be(true)
+
+      expect(open_circuit.run { 'ok' }).to eq('ok')
+
+      expect(open_circuit.status.closed?).to be(true)
+      expect(open_circuit.status.reserved_at).to be_nil
+    end
+
+    it 'clears reserved_at on reset' do
+      open_circuit
+      Timecop.freeze(Time.now + 300)
+      expect(storage.reserve(open_circuit, Faulty.current_time, nil)).to be(true)
+      expect(open_circuit.status.reserved_at).not_to be_nil
+
+      open_circuit.reset!
+      expect(open_circuit.status.reserved_at).to be_nil
     end
 
     it 'skips running if open' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ require 'json'
 require 'connection_pool'
 
 begin
+  ENV['MYSQL_HOST'] ||= '127.0.0.1'
+  ENV['MYSQL_USER'] ||= 'root'
   require 'faulty/patch/mysql2'
 rescue LoadError
   # Ok if mysql2 isn't available (e.g. JRuby/TruffleRuby)

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe Faulty::Status do
     it('can run') { expect(status.can_run?).to be(true) }
   end
 
+  context 'when locked closed and reserved' do
+    subject(:status) do
+      described_class.new(
+        options: options,
+        state: :open,
+        opened_at: Faulty.current_time,
+        reserved_at: Faulty.current_time,
+        lock: :closed
+      )
+    end
+
+    it('is reserved') { expect(status).to be_reserved }
+    it('can run regardless of reservation') { expect(status.can_run?).to be(true) }
+  end
+
   context 'when sample size is too small' do
     subject(:status) { described_class.new(options: options, sample_size: 1, failure_rate: 0.99) }
 
@@ -98,5 +113,85 @@ RSpec.describe Faulty::Status do
   it 'requires opened_at if state is open' do
     expect { described_class.new(options: options, state: :open) }
       .to raise_error(ArgumentError, /opened_at is required if state is open/)
+  end
+
+  # Defends the invariant that `reserved_at` is meaningful only while
+  # `state == :open`. A brief race in `Memory#close` can produce a snapshot
+  # where `state` has flipped to `:closed` before `reserved_at` was reset;
+  # normalizing here means downstream code (and event-listener payloads)
+  # never has to special-case that transient shape.
+  it 'normalizes reserved_at to nil when state is closed' do
+    status = described_class.new(
+      options: options,
+      state: :closed,
+      reserved_at: Faulty.current_time
+    )
+    expect(status.reserved_at).to be_nil
+  end
+
+  it 'preserves reserved_at when state is open' do
+    reserved_at = Faulty.current_time
+    status = described_class.new(
+      options: options,
+      state: :open,
+      opened_at: Faulty.current_time,
+      reserved_at: reserved_at
+    )
+    expect(status.reserved_at).to eq(reserved_at)
+  end
+
+  # Direct coverage for the Status#reserved? predicate. The case "state is
+  # :closed with a non-nil reserved_at" is not tested here because
+  # Status#finalize normalizes reserved_at to nil at construction time —
+  # see 'normalizes reserved_at to nil when state is closed' above.
+  describe '#reserved?' do
+    # cool_down defaults to 300; pin current_time relative to that so the
+    # boundary and expired examples are deterministic without Timecop.
+    let(:now) { 1_000_000.0 }
+
+    it 'is false when reserved_at is nil' do
+      status = described_class.new(
+        options: options,
+        state: :open,
+        opened_at: now,
+        current_time: now
+      )
+      expect(status.reserved?).to be(false)
+    end
+
+    it 'is true when state is open and within cool_down' do
+      status = described_class.new(
+        options: options,
+        state: :open,
+        opened_at: now,
+        reserved_at: now,
+        current_time: now
+      )
+      expect(status.reserved?).to be(true)
+    end
+
+    it 'is false when the reservation has fully expired' do
+      status = described_class.new(
+        options: options,
+        state: :open,
+        opened_at: now - 1000,
+        reserved_at: now - 1000,
+        current_time: now
+      )
+      expect(status.reserved?).to be(false)
+    end
+
+    # Boundary: the predicate uses `>`, not `>=`, so a reservation exactly at
+    # the cool_down expiry is considered expired (the next process may retry).
+    it 'is false at the cool_down boundary' do
+      status = described_class.new(
+        options: options,
+        state: :open,
+        opened_at: now - options.cool_down,
+        reserved_at: now - options.cool_down,
+        current_time: now
+      )
+      expect(status.reserved?).to be(false)
+    end
   end
 end

--- a/spec/storage/circuit_proxy_spec.rb
+++ b/spec/storage/circuit_proxy_spec.rb
@@ -37,4 +37,12 @@ RSpec.describe Faulty::Storage::CircuitProxy do
     proxy = described_class.new(backend, notifier: notifier)
     proxy.entry(circuit, Faulty.current_time, true, nil)
   end
+
+  it 'delegates #reserve to the wrapped storage' do
+    backend = Faulty::Storage::Memory.new
+    proxy = described_class.new(backend, notifier: notifier)
+    allow(backend).to receive(:reserve).with(circuit, 100.0, nil).and_return(true)
+    expect(proxy.reserve(circuit, 100.0, nil)).to be(true)
+    expect(backend).to have_received(:reserve).with(circuit, 100.0, nil)
+  end
 end

--- a/spec/storage/fallback_chain_spec.rb
+++ b/spec/storage/fallback_chain_spec.rb
@@ -166,6 +166,13 @@ RSpec.describe Faulty::Storage::FallbackChain do
     it_behaves_like 'chained method'
   end
 
+  describe '#reserve' do
+    let(:action) { :reserve }
+    let(:args) { [circuit, Faulty.current_time, nil] }
+
+    it_behaves_like 'chained method'
+  end
+
   describe '#lock' do
     let(:action) { :lock }
     let(:args) { [circuit, :open] }

--- a/spec/storage/fault_tolerant_proxy_spec.rb
+++ b/spec/storage/fault_tolerant_proxy_spec.rb
@@ -115,6 +115,18 @@ RSpec.describe Faulty::Storage::FaultTolerantProxy do
     it_behaves_like 'safely wrapped action'
   end
 
+  # Unlike #open/#reopen/#close which return false on storage error,
+  # #reserve returns true to fail open — a degraded backend allows the
+  # half-open test run to proceed, trading thundering-herd protection for
+  # availability.
+  describe '#reserve' do
+    let(:action) { :reserve }
+    let(:args) { [circuit, Faulty.current_time, nil] }
+    let(:retval) { true }
+
+    it_behaves_like 'safely wrapped action'
+  end
+
   describe '#lock' do
     let(:action) { :lock }
     let(:args) { [circuit, :open] }

--- a/spec/storage/interface_spec.rb
+++ b/spec/storage/interface_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'faulty/storage/interface'
+
+# Conformance test for {Faulty::Storage::Interface}.
+#
+# Every concrete storage backend (and every wrapper that pretends to be one)
+# MUST implement every public instance method declared on the documentation
+# interface. This is the structural guard that prevents a future addition to
+# `Storage::Interface` from silently regressing wrappers like `CircuitProxy`
+# or `FallbackChain` that don't use `method_missing` or `Forwardable` for the
+# full surface.
+RSpec.describe Faulty::Storage::Interface do
+  interface_methods = described_class.public_instance_methods(false).sort
+
+  storage_classes = [
+    Faulty::Storage::Memory,
+    Faulty::Storage::Redis,
+    Faulty::Storage::Null,
+    Faulty::Storage::FallbackChain,
+    Faulty::Storage::FaultTolerantProxy,
+    Faulty::Storage::CircuitProxy
+  ]
+
+  storage_classes.each do |klass|
+    describe klass do
+      interface_methods.each do |method|
+        it "implements ##{method}" do
+          expect(klass.public_method_defined?(method)).to be(true),
+            "#{klass} is missing public method ##{method} required by Faulty::Storage::Interface"
+        end
+      end
+    end
+  end
+end

--- a/spec/storage/memory_spec.rb
+++ b/spec/storage/memory_spec.rb
@@ -18,4 +18,32 @@ RSpec.describe Faulty::Storage::Memory do
     expect(storage.list).to eq([])
     expect(storage.history(circuit)).to eq([])
   end
+
+  # Preserving reserved_at across reopen is load-bearing for half-open
+  # exclusivity. If a late-arriving process E read status while reserved_at
+  # was still nil (before the winning process A reserved), and A then
+  # reserved, ran, failed, and reopened, E's CAS(nil -> T_E) would
+  # incorrectly succeed if reopen cleared reserved_at to nil. The current
+  # value (the reservation A made) must survive reopen so E's CAS sees a
+  # mismatch and skips.
+  it 'does not clear reserved_at on reopen' do
+    storage = described_class.new
+    storage.open(circuit, 100.0)
+    storage.reserve(circuit, 100.0, nil)
+    storage.reopen(circuit, 200.0, 100.0)
+    expect(storage.status(circuit).reserved_at).to eq(100.0)
+  end
+
+  # The threaded test in spec/circuit_spec.rb only exercises the
+  # Status#reserved? short-circuit — the loser bails before ever calling
+  # storage.reserve. This direct CAS test exercises
+  # Concurrent::Atom#compare_and_set and would fail if Memory#reserve
+  # regressed to a non-atomic implementation.
+  it 'reserves the circuit once when called concurrently', :concurrency do
+    storage = described_class.new
+    result = concurrently(50) do
+      storage.reserve(circuit, Faulty.current_time, nil)
+    end
+    expect(result.count { |r| r }).to eq(1)
+  end
 end

--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe Faulty::Storage::Redis do
       end
       expect(result.count { |r| r }).to eq(1)
     end
+
+    it 'reserves the circuit once when called concurrently', :concurrency do
+      concurrent_warmup do
+        storage.unlock(circuit)
+      end
+
+      result = concurrently(pool_size) do
+        storage.reserve(circuit, Faulty.current_time, nil)
+      end
+      expect(result.count { |r| r }).to eq(1)
+    end
   end
 
   context 'when Redis has high timeout' do
@@ -100,6 +111,17 @@ RSpec.describe Faulty::Storage::Redis do
     it 'warns and continues' do
       expect { storage }.to output(/while checking client options: fail/).to_stderr
     end
+  end
+
+  # See spec/storage/memory_spec.rb for the rationale: preserving reserved_at
+  # across reopen is load-bearing for half-open exclusivity against
+  # late-arriving callers whose status snapshot saw reserved_at == nil from
+  # before the winning process reserved.
+  it 'does not clear reserved_at on reopen' do
+    storage.open(circuit, 100.0)
+    storage.reserve(circuit, 100.0, nil)
+    storage.reopen(circuit, 200.0, 100.0)
+    expect(storage.status(circuit).reserved_at).to eq(100.0)
   end
 
   context 'when opened_at is missing and status is open' do


### PR DESCRIPTION
## Summary

Reserve half-open test runs across processes so only one process executes the test block when a circuit becomes half-open. Other processes that observe the half-open state while a test run is in flight now skip with `OpenCircuitError` and emit a `:circuit_skipped` event, matching the existing semantics for an open circuit.

Exclusivity is provided by a new compare-and-set storage method, `Storage::Interface#reserve`, alongside `reserved_at` and `current_time` fields on `Status`. The reservation expires after `cool_down` so a crashed reserver auto-recovers; the worst-case behaviour is one extra test run per `cool_down` window when a protected block runs longer than `cool_down`.

## Background: the half-open race

In a circuit breaker, the **half-open** state is meant to admit a **single probe** through to test whether the upstream has recovered. The pre-existing Faulty implementation didn't enforce this — any caller that observed `half_open?` would run the protected block — so under concurrent load the cool-down window degenerated into a thundering herd of probes against an upstream that might still be unhealthy.

### Without coordination (status quo on `master`)

```mermaid
sequenceDiagram
    participant W1 as Worker 1
    participant W2 as Worker 2
    participant W3 as Worker 3
    participant S as Storage
    participant U as Upstream (still flaky)

    Note over S: state=open<br/>cool_down has elapsed<br/>(reads as half_open)

    par
        W1->>S: status
        S-->>W1: half_open
    and
        W2->>S: status
        S-->>W2: half_open
    and
        W3->>S: status
        S-->>W3: half_open
    end

    Note over W1,W3: Each worker concludes<br/>"I am THE probe"

    rect rgb(255, 226, 226)
    par
        W1->>U: protected call
    and
        W2->>U: protected call
    and
        W3->>U: protected call
    end
    Note over U: Re-overloaded —<br/>circuit re-opens,<br/>cool_down restarts
    end
```

The visible symptoms in production were:

- Bursty re-failures the instant `cool_down` expires (every worker probing in lock-step).
- A flaky upstream that would otherwise recover gets repeatedly knocked back over by its own probe storm.
- `:circuit_success` / `:circuit_failure` event counts spike by ~N on each half-open transition instead of yielding exactly one event.

### With reservation (this PR)

```mermaid
sequenceDiagram
    participant W1 as Worker 1
    participant W2 as Worker 2
    participant W3 as Worker 3
    participant S as Storage
    participant U as Upstream

    Note over S: state=half_open<br/>reserved_at=nil

    par
        W1->>S: status
        S-->>W1: half_open, reserved_at=nil
    and
        W2->>S: status
        S-->>W2: half_open, reserved_at=nil
    and
        W3->>S: status
        S-->>W3: half_open, reserved_at=nil
    end

    par CAS race on reserved_at
        W1->>S: reserve(now, prev=nil)
        S-->>W1: true
    and
        W2->>S: reserve(now, prev=nil)
        S-->>W2: false
    and
        W3->>S: reserve(now, prev=nil)
        S-->>W3: false
    end

    rect rgb(226, 245, 226)
    W1->>U: protected call (the probe)
    U-->>W1: success or failure
    Note over W1: close on success<br/>re-open on failure
    end

    rect rgb(255, 243, 224)
    Note over W2,W3: emit circuit_skipped event<br/>raise OpenCircuitError
    end
```

The CAS itself is `WATCH`/`MULTI`/`EXEC` on `circuit:<name>:reserved_at` in Redis and `Concurrent::Atom#compare_and_set` in Memory. The reservation expires after `cool_down`, so a worker that crashes mid-probe doesn't strand the circuit — the next caller after `cool_down` reads `reserved_at` as stale and wins a fresh CAS. Worst-case behaviour is one extra probe per `cool_down` window when a protected block runs longer than `cool_down`.

## Release

Releases as **0.13.0** once #78 (the 0.12.0 modernization PR) ships. The rebase target is the `modernize` branch, so the diff GitHub shows against `master` will narrow to just this feature once 0.12.0 merges.

## Storage backends

Custom `Storage::Interface` implementations must add a `#reserve(circuit, time, previous_reserved_at)` method:

* `Memory` — `Concurrent::Atom#compare_and_set` on `reserved_at`.
* `Redis` — `WATCH`/`MULTI`/`EXEC` on a new `circuit:<name>:reserved_at` key, expiring with `circuit_ttl`.
* `Null` — always returns `true`.
* `FaultTolerantProxy` — falls open on backend error.

## Also included

* `Status#can_run?` treats `locked_closed?` as an unconditional override above the reservation check, so a manually locked-closed circuit runs even with a stale reservation still in effect from a prior cycle.
* `Status` snapshots `current_time` at construction so `open?`, `half_open?`, and `reserved?` all reason about the same instant.
* `Storage::Redis#close` and `#reset` clear the `reserved_at` key.
* `Storage::Redis#reopen` and `#reserve` use safe navigation when serializing `previous_*_at`, fixing the first CAS against a missing key.
* `docker-compose.yml` for local infra (mysql, redis, opensearch) and matching `MYSQL_HOST` / `MYSQL_USER` defaults in the spec helper.

## Test plan

- [x] `bundle exec rubocop` clean
- [x] `bundle exec rspec` green (full suite against redis 4/5 via CI)
- [x] New `spec/circuit_spec.rb` coverage for the half-open reservation path (single executor, skip event for losers)
- [x] New `spec/storage/redis_spec.rb` concurrency example asserts exactly one reserver wins under pool contention
- [x] `spec/status_spec.rb` coverage for snapshotted `current_time` and `locked_closed?` override
