### PR TITLE
`redis-clustering` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', jruby-head, truffleruby-head]
-        redis: ['4']
+        redis: ['4', '5']
+        redis_cluster: [false, true]
         search: [['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']]
         include:
           # Redis 3
@@ -36,11 +37,20 @@ jobs:
           - ruby: '2.3'
             redis: '4'
             search: ['elasticsearch:7.5.0', 'elasticsearch:7.13.4']
+        exclude:
+          # redis-clustering requires Ruby >= 2.7
+          - ruby: '2.3'
+            redis_cluster: true
+          - ruby: '2.4'
+            redis_cluster: true
+          - ruby: '2.5'
+            redis_cluster: true
+          - ruby: '2.6'
+            redis_cluster: true
+          # redis-clustering first release is 5.x
+          - redis: '4'
+            redis_cluster: true
     services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
       search:
         image: ${{ matrix.search[1] }}
         ports:
@@ -56,6 +66,7 @@ jobs:
 
     env:
       REDIS_VERSION: ${{ matrix.redis }}
+      REDIS_CLUSTER: ${{ matrix.redis_cluster && 'true' || '' }}
       SEARCH_GEM: ${{ matrix.search[0] }}
 
     steps:
@@ -64,6 +75,14 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Start Redis (single instance)
+        if: ${{ !matrix.redis_cluster }}
+        run: |
+          docker run -d --name redis -p 6379:6379 redis
+      - name: Start Redis Cluster
+        if: ${{ matrix.redis_cluster }}
+        run: |
+          docker compose -f docker-compose.redis-cluster.yml up -d --wait
       - name: start MySQL
         run: sudo /etc/init.d/mysql start
       - run: bundle exec rspec --format doc

--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,20 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
   gem 'simplecov-cobertura', '~> 2.1'
 end
 
-if ENV['REDIS_VERSION']
-  gem 'redis', "~> #{ENV['REDIS_VERSION']}"
+if (redis_version = ENV.fetch('REDIS_VERSION', nil))
+  gem 'redis', "~> #{redis_version}"
 end
 
-if ENV['SEARCH_GEM']
-  name, version = ENV['SEARCH_GEM'].split(':')
+if redis_version
+  if ENV.fetch('REDIS_CLUSTER', nil) == 'true'
+    gem 'redis-clustering', "~> #{redis_version}"
+  end
+elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+  gem 'redis-clustering' # rubocop:disable Bundler/DuplicatedGem
+end
+
+if (search_gem = ENV.fetch('SEARCH_GEM', nil))
+  name, version = search_gem.split(':')
   name = 'opensearch-ruby' if name == 'opensearch'
   gem name, "~> #{version}"
 else

--- a/docker-compose.redis-cluster.yml
+++ b/docker-compose.redis-cluster.yml
@@ -1,0 +1,72 @@
+services:
+  redis-cluster-node-0:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-0:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-1:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-1:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-2:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-2:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-3:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-3:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-4:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-4:/bitnami/redis/data
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+
+  redis-cluster-node-5:
+    image: docker.io/bitnami/redis-cluster:latest
+    volumes:
+      - redis-cluster_data-5:/bitnami/redis/data
+    depends_on:
+      - redis-cluster-node-0
+      - redis-cluster-node-1
+      - redis-cluster-node-2
+      - redis-cluster-node-3
+      - redis-cluster-node-4
+    environment:
+      - "ALLOW_EMPTY_PASSWORD=yes"
+      - "REDIS_CLUSTER_REPLICAS=1"
+      - "REDIS_NODES=redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4 redis-cluster-node-5"
+      - "REDIS_CLUSTER_CREATOR=yes"
+    ports:
+      - "6379:6379"
+
+volumes:
+  redis-cluster_data-0:
+    driver: local
+  redis-cluster_data-1:
+    driver: local
+  redis-cluster_data-2:
+    driver: local
+  redis-cluster_data-3:
+    driver: local
+  redis-cluster_data-4:
+    driver: local
+  redis-cluster_data-5:
+    driver: local

--- a/lib/faulty/patch/redis.rb
+++ b/lib/faulty/patch/redis.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'redis'
+begin
+  require 'redis-clustering'
+rescue LoadError
+  nil
+end
 
 class Faulty
   module Patch

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -293,7 +293,7 @@ class Faulty
       end
 
       def ckey(circuit_name, *parts)
-        key('circuit', circuit_name, *parts)
+        key('circuit', hashtag(circuit_name), *parts)
       end
 
       # @return [String] The key for circuit options
@@ -323,7 +323,7 @@ class Faulty
 
       # Get the current key to add circuit names to
       def list_key
-        key('list', current_list_block)
+        key('list', hashtag(current_list_block))
       end
 
       # Get all active circuit list keys
@@ -348,8 +348,12 @@ class Faulty
         num_blocks = (options.circuit_ttl.to_f / options.list_granularity).floor + 1
         start_block = current_list_block - num_blocks + 1
         num_blocks.times.map do |i|
-          key('list', start_block + i)
+          key('list', hashtag(start_block + i))
         end
+      end
+
+      def hashtag(part)
+        "{#{part}}"
       end
 
       # Get the block number for the current list set
@@ -372,11 +376,11 @@ class Faulty
       #   inside the block
       def watch_exec(key, old, &block)
         redis do |r|
-          r.watch(key) do
-            if old.include?(r.get(key))
-              r.multi(&block)
+          r.watch(key) do |c|
+            if old.include?(c.get(key))
+              c.multi(&block)
             else
-              r.unwatch
+              c.unwatch
               nil
             end
           end
@@ -424,11 +428,21 @@ class Faulty
         warn "Faulty error while checking client options: #{e.message}"
       end
 
-      def check_redis_options!
+      def check_redis_options! # rubocop:disable Metrics/MethodLength
         gte5 = ::Redis::VERSION.to_f >= 5
-        method = gte5 ? :config : :options
         ropts = redis do |r|
-          r.instance_variable_get(:@client).public_send(method)
+          if r.instance_of?(::Redis)
+            method = gte5 ? :config : :options
+            if r.respond_to?(:_client)
+              r._client.public_send(method)
+            else
+              r.client.public_send(method)
+            end
+          elsif r.instance_of?(::Redis::Cluster)
+            r._client.config
+          else
+            raise TypeError, "Unsupported Redis client type: #{r.class}"
+          end
         end
 
         bad_timeouts = {}
@@ -445,7 +459,16 @@ class Faulty
           MSG
         end
 
-        gt1_retry = gte5 ? ropts.retry_connecting?(1, nil) : ropts[:reconnect_attempts] > 1
+        gt1_retry = redis do |r|
+          if r.instance_of?(::Redis)
+            gte5 ? ropts.retry_connecting?(1, nil) : ropts[:reconnect_attempts] > 1
+          elsif r.instance_of?(::Redis::Cluster)
+            ra = ropts.client_config[:reconnect_attempts]
+            (ra.is_a?(Array) && ra.length > 1) || ra > 1
+          else
+            raise TypeError, "Unsupported Redis client type: #{r.class}"
+          end
+        end
         if gt1_retry
           warn <<~MSG
             Faulty recommends setting Redis reconnect_attempts to <= 1 to


### PR DESCRIPTION
Closes https://github.com/ParentSquare/faulty/issues/71.

This is a scope-cut version of https://github.com/buildkite/faulty/pull/1 (it included other CI and related changes similar to https://github.com/ParentSquare/faulty/pull/72).