### PR TITLE
Release 0.12.0: modernize toolchain and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,30 +12,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', jruby-head, truffleruby-head]
-        redis: ['4']
-        search: [['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']]
+        ruby: ['3.1', '3.2', '3.3', '3.4', jruby-head, truffleruby-head]
+        redis: ['5']
+        search: [['opensearch-ruby:3.4.0', 'opensearchproject/opensearch:2.19.5']]
         include:
-          # Redis 3
-          - ruby: '2.7'
-            redis: '3'
-            search: ['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']
-          # Opensearch 1.0
-          - ruby: '2.7'
+          # Redis 4
+          - ruby: '3.4'
             redis: '4'
-            search: ['opensearch-ruby:1.0.1', 'opensearchproject/opensearch:1.0.1']
-          # Elasticsearch 7.13
-          - ruby: '2.7'
-            redis: '4'
-            search: ['elasticsearch:7.13.3', 'elasticsearch:7.13.4']
-          # Redis 5
-          - ruby: '2.7'
+            search: ['opensearch-ruby:3.4.0', 'opensearchproject/opensearch:2.19.5']
+          # OpenSearch 3.x
+          - ruby: '3.4'
             redis: '5'
-            search: ['opensearch-ruby:2.1.0', 'opensearchproject/opensearch:2.2.1']
-          # Ruby 2.3 & Elasticsearch 7.5
-          - ruby: '2.3'
-            redis: '4'
-            search: ['elasticsearch:7.5.0', 'elasticsearch:7.13.4']
+            search: ['opensearch-ruby:3.4.0', 'opensearchproject/opensearch:3.0.0']
+          # Elasticsearch 7.17 (last release of the pre-8 transport API
+          # that the Faulty patch currently targets). ES 8+ moves the
+          # transport into the `elastic-transport` gem under
+          # `Elastic::Transport`, which the patch does not yet support.
+          - ruby: '3.4'
+            redis: '5'
+            search: ['elasticsearch:7.17.11', 'elasticsearch:7.17.28']
     services:
       redis:
         image: redis
@@ -48,6 +43,13 @@ jobs:
         env:
           discovery.type: single-node
           plugins.security.disabled: ${{ contains(matrix.search[1], 'opensearch') && 'true' || '' }}
+          xpack.security.enabled: ${{ contains(matrix.search[1], 'elasticsearch') && 'false' || '' }}
+          # OpenSearch 2.12+ requires an initial admin password for the
+          # security demo installer (which still runs even with
+          # `plugins.security.disabled=true`). Skip the demo config
+          # entirely so we don't have to set a placeholder password.
+          # Older OpenSearch and all Elasticsearch images ignore this.
+          DISABLE_INSTALL_DEMO_CONFIG: 'true'
         options: >-
           --health-cmd="curl http://localhost:9200/_cluster/health"
           --health-interval=3s
@@ -59,7 +61,7 @@ jobs:
       SEARCH_GEM: ${{ matrix.search[0] }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -70,28 +72,28 @@ jobs:
         env:
           MYSQL_USER: root
           MYSQL_PASSWORD: root
-      - uses: codecov/codecov-action@v3
-        if: matrix.ruby == '2.7'
+      - uses: codecov/codecov-action@v5
+        if: matrix.ruby == '3.4'
         with:
           files: coverage/coverage.xml
 
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bundle exec rubocop
 
   yard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bin/yardoc --fail-on-warning
 
@@ -99,10 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.4'
           bundler-cache: true
       - run: bin/check-version
 
@@ -111,7 +113,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dawidd6/action-publish-gem@v1
         with:
           api_key: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,16 @@
 ---
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  SuggestExtensions: false
 
 Gemspec/DeprecatedAttributeAssignment: { Enabled: true }
+# Faulty intentionally keeps essential dev deps in the gemspec; the rest
+# live in the Gemfile (per the comment in faulty.gemspec).
+Gemspec/DevelopmentDependencies: { Enabled: false }
 Gemspec/RequireMFA: { Enabled: true }
 
 Layout/ArgumentAlignment: { EnforcedStyle: with_fixed_indentation }
@@ -54,19 +59,22 @@ Lint/UselessRuby2Keywords: { Enabled: true }
 
 RSpec/BeEq: { Enabled: true }
 RSpec/BeNil: { Enabled: true }
-RSpec/Capybara/SpecificMatcher: { Enabled: true }
 RSpec/ChangeByZero: { Enabled: true }
 RSpec/ExampleLength: { Enabled: false }
 RSpec/ExcessiveDocstringSpacing: { Enabled: true }
-RSpec/FactoryBot/SyntaxMethods: { Enabled: true }
-RSpec/FilePath: { Enabled: false }
 RSpec/IdenticalEqualityAssertion: { Enabled: true }
+# auto_wire_spec deliberately exercises wiring multiple instances of the
+# same backend, where numeric suffixes (storage1/storage2) read clearer
+# than any contrived semantic name.
+RSpec/IndexedLet:
+  Exclude:
+    - 'spec/storage/auto_wire_spec.rb'
 RSpec/MessageSpies: { Enabled: false }
 RSpec/MultipleExpectations: { Enabled: false }
 RSpec/MultipleMemoizedHelpers: { Enabled: false }
 RSpec/NamedSubject: { Enabled: false }
-RSpec/Rails/AvoidSetupHook: { Enabled: true }
-RSpec/Rails/HaveHttpStatus: { Enabled: true }
+RSpec/SpecFilePathFormat: { Enabled: false }
+RSpec/SpecFilePathSuffix: { Enabled: false }
 RSpec/SubjectDeclaration: { Enabled: true }
 RSpec/SubjectStub: { Enabled: false }
 RSpec/VerifiedDoubleReference: { Enabled: true }
@@ -80,6 +88,12 @@ Metrics/PerceivedComplexity: { Enabled: false }
 
 Naming/BlockForwarding: { Enabled: true }
 Naming/MethodParameterName: { MinNameLength: 1 }
+# Storage interface methods like #open / #close / #reopen are imperative
+# actions, not predicates — they happen to return a boolean to indicate
+# success. Renaming them would break the public Storage::Interface contract.
+Naming/PredicateMethod:
+  Exclude:
+    - 'lib/faulty/storage/**/*.rb'
 
 Security/CompoundHash: { Enabled: true }
 Security/IoMethods: { Enabled: true }
@@ -115,6 +129,11 @@ Style/NilLambda: { Enabled: true }
 Style/NumberedParameters: { Enabled: true }
 Style/NumberedParametersLimit: { Enabled: true }
 Style/ObjectThen: { Enabled: true }
+# Patch files monkey-patch upstream constants (Redis, Mysql2) and so
+# necessarily reopen multiple top-level modules in the same file.
+Style/OneClassPerFile:
+  Exclude:
+    - 'lib/faulty/patch/**/*.rb'
 Style/OpenStructUse: { Enabled: true }
 Style/QuotedSymbols: { Enabled: true }
 Style/RedundantArgument: { Enabled: true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 -------------------
 
+[0.12.0] - 2026-05-13
+---------------------
+
+Runtime behavior is unchanged from `0.11.0` — the version bump reflects
+support-policy and toolchain breaking changes only. Upgrading should be
+a drop-in replacement on any supported Ruby.
+
+### Breaking
+
+* Drop support for Ruby < 3.1. Ruby 2.3 – 3.0 are EOL upstream and are no
+  longer covered by CI. Faulty now requires Ruby 3.1 or newer.
+* `faulty.gemspec` declares `required_ruby_version = '>= 3.1'`, so older
+  Rubies will refuse to install the gem.
+
+### Changed
+
+* Modernize the CI matrix: Ruby `3.1`, `3.2`, `3.3`, `3.4`, `jruby-head`,
+  and `truffleruby-head`; Redis 4 and 5; OpenSearch `2.19.5` (default) and
+  `3.0.0`; Elasticsearch `7.17.x` for back-compat coverage. The
+  Elasticsearch 7.17 row runs the `elasticsearch:7.17.28` Docker image
+  (which ships a JDK that handles cgroupv2 on current runners) against
+  the `elasticsearch ~> 7.17.11` gem.
+* Pass `DISABLE_INSTALL_DEMO_CONFIG=true` to the OpenSearch service
+  container so OpenSearch 2.12+ doesn't require an admin-password env
+  var just to boot up with the security plugin disabled.
+* Replace the deprecated `:mingw` / `:x64_mingw` platform symbols in the
+  `Gemfile` with the unified `:windows` symbol Bundler now expects.
+* Upgrade development dependencies: `rubocop ~> 1.84`, `rubocop-rspec ~> 3.9`,
+  `simplecov-cobertura ~> 3.1`, `opensearch-ruby ~> 3.4`.
+* `LogListener` now lazy-requires `logger` only when constructing the
+  default `Logger.new($stderr)`. Consumers that pass their own logger or
+  run under Rails do not need the stdlib `logger` gem on the load path.
+  This keeps Faulty boot-clean on Ruby 3.5+ where `logger` is no longer a
+  default gem.
+
+### Removed
+
+* Drop Redis 3 from the test matrix.
+* Drop the Ruby 2.3 carve-out in `spec/spec_helper.rb` that conditionally
+  loaded the `mysql2` patch.
+
 [0.11.0] - 2023-04-26
 ---------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,11 @@ gem 'activesupport', '>= 4.2'
 gem 'byebug', platforms: not_jruby
 gem 'honeybadger', '>= 2.0'
 gem 'irb', '~> 1.0'
+# stdlib `logger` became a bundled gem in Ruby 3.5. The runtime only needs
+# it when the default LogListener actually constructs a Logger; we pull it
+# in here so the test suite and `bin/benchmark` boot the default Faulty
+# pipeline without forcing it on consumers who supply their own listeners.
+gem 'logger'
 # Minimum of 0.5.0 for specific error classes
 gem 'mysql2', '>= 0.5.0', platforms: not_jruby
 gem 'redcarpet', '~> 3.5', platforms: not_jruby

--- a/Gemfile
+++ b/Gemfile
@@ -8,27 +8,21 @@ gemspec
 # here. This also allows us to use conditional dependencies that depend on the
 # platform
 
-not_jruby = %i[ruby mingw x64_mingw].freeze
+not_jruby = %i[ruby windows].freeze
 
 gem 'activesupport', '>= 4.2'
 gem 'byebug', platforms: not_jruby
+gem 'honeybadger', '>= 2.0'
 gem 'irb', '~> 1.0'
 # Minimum of 0.5.0 for specific error classes
 gem 'mysql2', '>= 0.5.0', platforms: not_jruby
 gem 'redcarpet', '~> 3.5', platforms: not_jruby
 gem 'rspec_junit_formatter', '~> 0.4'
+gem 'rubocop', '~> 1.84'
+gem 'rubocop-rspec', '~> 3.9'
+gem 'simplecov', '>= 0.17.1'
+gem 'simplecov-cobertura', '~> 3.1'
 gem 'yard', '~> 0.9.25', platforms: not_jruby
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
-  gem 'honeybadger', '>= 2.0'
-end
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
-  gem 'rubocop', '~> 1.32.0'
-  gem 'rubocop-rspec', '~> 2.12'
-  gem 'simplecov', '>= 0.17.1'
-  gem 'simplecov-cobertura', '~> 2.1'
-end
 
 if ENV['REDIS_VERSION']
   gem 'redis', "~> #{ENV['REDIS_VERSION']}"
@@ -39,5 +33,5 @@ if ENV['SEARCH_GEM']
   name = 'opensearch-ruby' if name == 'opensearch'
   gem name, "~> #{version}"
 else
-  gem 'opensearch-ruby', '~> 2.1'
+  gem 'opensearch-ruby', '~> 3.4'
 end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -18,11 +18,9 @@ Benchmark.bm(width) do |b|
 
   b.report('memory storage failures') do
     n.times do
-      begin
-        in_memory.circuit(:memory_fail, sample_threshold: n + 1).run { raise 'fail' }
-      rescue StandardError
-        # Expected to raise here
-      end
+      in_memory.circuit(:memory_fail, sample_threshold: n + 1).run { raise 'fail' }
+    rescue StandardError
+      # Expected to raise here
     end
   end
 
@@ -42,11 +40,9 @@ Benchmark.bm(width) do |b|
 
   b.report('redis storage failures') do
     n.times do
-      begin
-        redis.circuit(:memory_fail, sample_threshold: n + 1).run { raise 'fail' }
-      rescue StandardError
-        # Expected to raise here
-      end
+      redis.circuit(:memory_fail, sample_threshold: n + 1).run { raise 'fail' }
+    rescue StandardError
+      # Expected to raise here
     end
   end
 

--- a/faulty.gemspec
+++ b/faulty.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*.rb', '*.md', '*.txt', '.yardopts']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 3.1'
 
-  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0'
 
   # Only essential development tools and dependencies go here.
   # Other non-essential development dependencies go in the Gemfile.

--- a/lib/faulty.rb
+++ b/lib/faulty.rb
@@ -41,12 +41,12 @@ class Faulty
     # @param config [Hash] Attributes for {Faulty::Options}
     # @yield [Faulty::Options] For setting options in a block
     # @return [self]
-    def init(default_name = :default, **config, &block)
+    def init(default_name = :default, **config, &)
       raise AlreadyInitializedError if @instances
 
       @default_instance = default_name
       @instances = Concurrent::Map.new
-      register(default_name, new(**config, &block)) unless default_name.nil?
+      register(default_name, new(**config, &)) unless default_name.nil?
       self
     rescue StandardError
       @instances = nil
@@ -110,8 +110,8 @@ class Faulty
     # @param (see Faulty#circuit)
     # @yield (see Faulty#circuit)
     # @return (see Faulty#circuit)
-    def circuit(name, **config, &block)
-      default.circuit(name, **config, &block)
+    def circuit(name, **config, &)
+      default.circuit(name, **config, &)
     end
 
     # Get a list of all circuit names for the default instance
@@ -236,8 +236,8 @@ class Faulty
   # @see Options
   # @param options [Hash] Attributes for {Options}
   # @yield [Options] For setting options in a block
-  def initialize(**options, &block)
-    @options = Options.new(options, &block)
+  def initialize(**options, &)
+    @options = Options.new(options, &)
     @registry = CircuitRegistry.new(circuit_options)
   end
 
@@ -252,9 +252,9 @@ class Faulty
   # @param options [Hash] Attributes for {Circuit::Options}
   # @yield [Circuit::Options] For setting options in a block
   # @return [Circuit] The new circuit or the existing circuit if it already exists
-  def circuit(name, **options, &block)
+  def circuit(name, **options, &)
     name = name.to_s
-    @registry.retrieve(name, options, &block)
+    @registry.retrieve(name, options, &)
   end
 
   # Get a list of all circuit names
@@ -285,7 +285,7 @@ class Faulty
   # @return [Hash] The circuit options
   def circuit_options
     @options.to_h
-      .select { |k, _v| %i[cache storage notifier].include?(k) }
+      .slice(:cache, :storage, :notifier)
       .merge(options.circuit_defaults)
   end
 end

--- a/lib/faulty/cache/auto_wire.rb
+++ b/lib/faulty/cache/auto_wire.rb
@@ -37,8 +37,8 @@ class Faulty
         # @param cache [Interface] A cache backend
         # @param options [Hash] Attributes for {Options}
         # @yield [Options] For setting options in a block
-        def wrap(cache, **options, &block)
-          options = Options.new(options, &block)
+        def wrap(cache, **options, &)
+          options = Options.new(options, &)
           if cache.nil?
             Cache::Default.new
           elsif cache.fault_tolerant?

--- a/lib/faulty/cache/circuit_proxy.rb
+++ b/lib/faulty/cache/circuit_proxy.rb
@@ -40,9 +40,9 @@ class Faulty
       # @param cache [Cache::Interface] The cache backend to wrap
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(cache, **options, &block)
+      def initialize(cache, **options, &)
         @cache = cache
-        @options = Options.new(options, &block)
+        @options = Options.new(options, &)
       end
 
       %i[read write].each do |method|

--- a/lib/faulty/cache/fault_tolerant_proxy.rb
+++ b/lib/faulty/cache/fault_tolerant_proxy.rb
@@ -30,19 +30,19 @@ class Faulty
       # @param cache [Cache::Interface] The cache backend to wrap
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(cache, **options, &block)
+      def initialize(cache, **options, &)
         @cache = cache
-        @options = Options.new(options, &block)
+        @options = Options.new(options, &)
       end
 
       # Wrap a cache in a FaultTolerantProxy unless it's already fault tolerant
       #
       # @param cache [Cache::Interface] The cache to maybe wrap
       # @return [Cache::Interface] The original cache or a {FaultTolerantProxy}
-      def self.wrap(cache, **options, &block)
+      def self.wrap(cache, ...)
         return cache if cache.fault_tolerant?
 
-        new(cache, **options, &block)
+        new(cache, ...)
       end
 
       # Read from the cache safely

--- a/lib/faulty/circuit.rb
+++ b/lib/faulty/circuit.rb
@@ -178,11 +178,11 @@ class Faulty
     # @param name [String] The name of the circuit
     # @param options [Hash] Attributes for {Options}
     # @yield [Options] For setting options in a block
-    def initialize(name, **options, &block)
+    def initialize(name, **options, &)
       raise ArgumentError, 'name must be a String' unless name.is_a?(String)
 
       @name = name
-      @given_options = Options.new(options, &block)
+      @given_options = Options.new(options, &)
       @pulled_options = nil
       @options_pushed = false
     end
@@ -266,8 +266,8 @@ class Faulty
     # @return [Result<Object, Error>] A result where the ok value is the return
     #   value of the block, or the error value is an error captured by the
     #   circuit.
-    def try_run(**options, &block)
-      Result.new(ok: run(**options, &block))
+    def try_run(...)
+      Result.new(ok: run(...))
     rescue FaultyError => e
       Result.new(error: e)
     end

--- a/lib/faulty/error.rb
+++ b/lib/faulty/error.rb
@@ -8,7 +8,7 @@ class Faulty
   class UninitializedError < FaultyError
     def initialize(message = nil)
       message ||= 'Faulty is not initialized'
-      super(message)
+      super
     end
   end
 
@@ -16,7 +16,7 @@ class Faulty
   class AlreadyInitializedError < FaultyError
     def initialize(message = nil)
       message ||= 'Faulty is already initialized'
-      super(message)
+      super
     end
   end
 
@@ -24,7 +24,7 @@ class Faulty
   class MissingDefaultInstanceError < FaultyError
     def initialize(message = nil)
       message ||= 'No default instance. Create one with init or get your instance with Faulty[:name]'
-      super(message)
+      super
     end
   end
 

--- a/lib/faulty/events/log_listener.rb
+++ b/lib/faulty/events/log_listener.rb
@@ -10,8 +10,17 @@ class Faulty
       #   by default if available, otherwise it creates a new `Logger` to
       #   stderr.
       def initialize(logger = nil)
-        logger ||= defined?(Rails) ? Rails.logger : ::Logger.new($stderr)
-        @logger = logger
+        @logger = if logger
+          logger
+        elsif defined?(Rails)
+          Rails.logger
+        else
+          # Lazy-require so consumers who pass their own logger or use Rails
+          # don't need the stdlib `logger` gem on the load path. Required for
+          # Ruby >= 3.5 where `logger` was extracted from the default gems.
+          require 'logger'
+          ::Logger.new($stderr)
+        end
       end
 
       # (see ListenerInterface#handle)

--- a/lib/faulty/events/notifier.rb
+++ b/lib/faulty/events/notifier.rb
@@ -22,11 +22,9 @@ class Faulty
         raise ArgumentError, "Unknown event #{event}" unless EVENTS.include?(event)
 
         @listeners.each do |listener|
-          begin
-            listener.handle(event, payload)
-          rescue StandardError => e
-            warn "Faulty listener #{listener.class.name} crashed: #{e.message}"
-          end
+          listener.handle(event, payload)
+        rescue StandardError => e
+          warn "Faulty listener #{listener.class.name} crashed: #{e.message}"
         end
       end
     end

--- a/lib/faulty/immutable_options.rb
+++ b/lib/faulty/immutable_options.rb
@@ -5,12 +5,12 @@ class Faulty
   module ImmutableOptions
     # @param hash [Hash] A hash of attributes to initialize with
     # @yield [self] Yields itself to the block to set options before freezing
-    def initialize(hash, &block)
-      setup(defaults.merge(hash), &block)
+    def initialize(hash, &)
+      setup(defaults.merge(hash), &)
     end
 
-    def dup_with(hash, &block)
-      dup.setup(hash, &block)
+    def dup_with(hash, &)
+      dup.setup(hash, &)
     end
 
     def setup(hash)

--- a/lib/faulty/patch.rb
+++ b/lib/faulty/patch.rb
@@ -75,7 +75,7 @@ class Faulty
       #   `:error_mapper`
       # @yield [Circuit::Options] For setting override options in a block
       # @return [Circuit, nil] The circuit if one was created
-      def circuit_from_hash(default_name, hash, **options, &block)
+      def circuit_from_hash(default_name, hash, **options, &)
         return unless hash
 
         hash = symbolize_keys(hash)
@@ -84,7 +84,7 @@ class Faulty
         error_mapper = options.delete(:patched_error_mapper)
         hash[:error_mapper] ||= error_mapper if error_mapper && patch_errors
         faulty = resolve_instance(hash.delete(:instance))
-        faulty.circuit(name, **hash, **options, &block)
+        faulty.circuit(name, **hash, **options, &)
       end
 
       # Create a full set of {CircuitError}s with a given base error class

--- a/lib/faulty/patch/base.rb
+++ b/lib/faulty/patch/base.rb
@@ -31,13 +31,13 @@ class Faulty
       #
       # @yield A block to run inside the circuit
       # @return The block return value
-      def faulty_run(&block)
+      def faulty_run(&)
         faulty_running_key = "faulty_running_#{object_id}"
         return yield unless @faulty_circuit
         return yield if Thread.current[faulty_running_key]
 
         Thread.current[faulty_running_key] = true
-        @faulty_circuit.run(&block)
+        @faulty_circuit.run(&)
       ensure
         Thread.current[faulty_running_key] = nil
       end

--- a/lib/faulty/patch/elasticsearch.rb
+++ b/lib/faulty/patch/elasticsearch.rb
@@ -54,7 +54,7 @@ class Faulty
       }
 
       module Errors
-        PATCHED_MODULE::Transport::Transport::ERRORS.each do |_code, klass|
+        PATCHED_MODULE::Transport::Transport::ERRORS.each_value do |klass|
           MAPPED_ERRORS[klass] = const_set(klass.name.split('::').last, Module.new)
         end
       end
@@ -69,7 +69,7 @@ class Faulty
       end
       private_constant :ERROR_MAPPER, :MAPPED_ERRORS
 
-      def initialize(arguments = {}, &block)
+      def initialize(arguments = {}, &)
         super
 
         errors = [PATCHED_MODULE::Transport::Transport::Error]

--- a/lib/faulty/patch/redis/patch.rb
+++ b/lib/faulty/patch/redis/patch.rb
@@ -55,7 +55,7 @@ class Faulty
       #
       # The call* methods above will then raise that error, so we are able to
       # capture it with faulty_run.
-      def io(&block)
+      def io(&)
         return super unless @faulty_circuit
 
         reply = super

--- a/lib/faulty/storage/auto_wire.rb
+++ b/lib/faulty/storage/auto_wire.rb
@@ -52,8 +52,8 @@ class Faulty
         #   of storage backends to setup.
         # @param options [Hash] Attributes for {Options}
         # @yield [Options] For setting options in a block
-        def wrap(storage, **options, &block)
-          options = Options.new(options, &block)
+        def wrap(storage, **options, &)
+          options = Options.new(options, &)
           if storage.nil?
             Memory.new
           elsif storage.is_a?(Array)

--- a/lib/faulty/storage/circuit_proxy.rb
+++ b/lib/faulty/storage/circuit_proxy.rb
@@ -40,9 +40,9 @@ class Faulty
       # @param storage [Storage::Interface] The storage backend to wrap
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(storage, **options, &block)
+      def initialize(storage, **options, &)
         @storage = storage
-        @options = Options.new(options, &block)
+        @options = Options.new(options, &)
       end
 
       %i[

--- a/lib/faulty/storage/fallback_chain.rb
+++ b/lib/faulty/storage/fallback_chain.rb
@@ -42,9 +42,9 @@ class Faulty
       #   additional entries will be tried in sequence until one succeeds.
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(storages, **options, &block)
+      def initialize(storages, **options, &)
         @storages = storages
-        @options = Options.new(options, &block)
+        @options = Options.new(options, &)
       end
 
       # Get options from the first available storage backend
@@ -189,12 +189,10 @@ class Faulty
       def send_chain(method, *args)
         errors = []
         @storages.each do |s|
-          begin
-            return s.public_send(method, *args)
-          rescue StandardError => e
-            errors << e
-            yield e
-          end
+          return s.public_send(method, *args)
+        rescue StandardError => e
+          errors << e
+          yield e
         end
 
         raise AllFailedError.new("#{self.class}##{method} failed for all storage backends", errors)
@@ -211,11 +209,9 @@ class Faulty
       def send_all(method, *args)
         errors = []
         @storages.each do |s|
-          begin
-            s.public_send(method, *args)
-          rescue StandardError => e
-            errors << e
-          end
+          s.public_send(method, *args)
+        rescue StandardError => e
+          errors << e
         end
 
         if errors.empty?

--- a/lib/faulty/storage/fault_tolerant_proxy.rb
+++ b/lib/faulty/storage/fault_tolerant_proxy.rb
@@ -31,9 +31,9 @@ class Faulty
       # @param storage [Storage::Interface] The storage backend to wrap
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(storage, **options, &block)
+      def initialize(storage, **options, &)
         @storage = storage
-        @options = Options.new(options, &block)
+        @options = Options.new(options, &)
       end
 
       # Wrap a storage backend in a FaultTolerantProxy unless it's already
@@ -41,10 +41,10 @@ class Faulty
       #
       # @param storage [Storage::Interface] The storage to maybe wrap
       # @return [Storage::Interface] The original storage or a {FaultTolerantProxy}
-      def self.wrap(storage, **options, &block)
+      def self.wrap(storage, ...)
         return storage if storage.fault_tolerant?
 
-        new(storage, **options, &block)
+        new(storage, ...)
       end
 
       # @!method lock(circuit, state)

--- a/lib/faulty/storage/memory.rb
+++ b/lib/faulty/storage/memory.rb
@@ -71,9 +71,9 @@ class Faulty
 
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(**options, &block)
+      def initialize(**options, &)
         @circuits = Concurrent::Map.new
-        @options = Options.new(options, &block)
+        @options = Options.new(options, &)
       end
 
       # Get the options stored for circuit

--- a/lib/faulty/storage/redis.rb
+++ b/lib/faulty/storage/redis.rb
@@ -80,8 +80,8 @@ class Faulty
 
       # @param options [Hash] Attributes for {Options}
       # @yield [Options] For setting options in a block
-      def initialize(**options, &block)
-        @options = Options.new(options, &block)
+      def initialize(**options, &)
+        @options = Options.new(options, &)
 
         # Ensure JSON is available since we don't explicitly require it
         JSON # rubocop:disable Lint/Void
@@ -387,9 +387,9 @@ class Faulty
       #
       # @yield [Redis] Yields the connection to the block
       # @return The value returned from the block
-      def redis(&block)
+      def redis(&)
         if options.client.respond_to?(:with)
-          options.client.with(&block)
+          options.client.with(&)
         else
           yield options.client
         end

--- a/lib/faulty/version.rb
+++ b/lib/faulty/version.rb
@@ -3,6 +3,6 @@
 class Faulty
   # The current Faulty version
   def self.version
-    Gem::Version.new('0.11.0')
+    Gem::Version.new('0.12.0')
   end
 end

--- a/spec/cache/default_spec.rb
+++ b/spec/cache/default_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Faulty::Cache::Default do
       it 'uses Rails.cache' do
         wrapper = cache.instance_variable_get(:@cache)
         expect(wrapper).to be_a(Faulty::Cache::Rails)
-        expect(wrapper.instance_variable_get(:@cache)).to eq(::Rails.cache)
+        expect(wrapper.instance_variable_get(:@cache)).to eq(Rails.cache)
       end
     end
   end

--- a/spec/cache/rails_spec.rb
+++ b/spec/cache/rails_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Faulty::Cache::Rails do
 
   it 'uses global Rails.cache by default' do
     cache = described_class.new
-    expect(cache.instance_variable_get(:@cache)).to eq(::Rails.cache)
+    expect(cache.instance_variable_get(:@cache)).to eq(Rails.cache)
     expect(cache).not_to be_fault_tolerant
   end
 

--- a/spec/circuit_spec.rb
+++ b/spec/circuit_spec.rb
@@ -6,7 +6,7 @@ RSpec.context :circuits do
   let(:circuit) { Faulty::Circuit.new('test', **options) }
 
   let(:open_circuit) do
-    circuit = Faulty::Circuit.new('test', **options.merge(rate_threshold: 0, sample_threshold: 0))
+    circuit = Faulty::Circuit.new('test', **options, rate_threshold: 0, sample_threshold: 0)
     circuit.try_run { raise 'failed' }
     circuit
   end
@@ -72,7 +72,7 @@ RSpec.context :circuits do
     end
 
     it 'raises a CircuitTrippedError when the threshold is passed' do
-      circuit = Faulty::Circuit.new('test', **options.merge(rate_threshold: 0, sample_threshold: 0))
+      circuit = Faulty::Circuit.new('test', **options, rate_threshold: 0, sample_threshold: 0)
       expect do
         circuit.run { raise 'failed' }
       end.to raise_error(
@@ -130,7 +130,7 @@ RSpec.context :circuits do
     end
 
     it 'does not close circuit until past sample threshold' do
-      circuit = Faulty::Circuit.new('test', **options.merge(rate_threshold: 0, sample_threshold: 2))
+      circuit = Faulty::Circuit.new('test', **options, rate_threshold: 0, sample_threshold: 2)
       circuit.try_run { raise 'fail' }
       expect(circuit.status.closed?).to be(true)
       circuit.try_run { raise 'fail' }
@@ -138,7 +138,7 @@ RSpec.context :circuits do
     end
 
     it 'does not close circuit until past rate threshold' do
-      circuit = Faulty::Circuit.new('test', **options.merge(rate_threshold: 0.6, sample_threshold: 0))
+      circuit = Faulty::Circuit.new('test', **options, rate_threshold: 0.6, sample_threshold: 0)
       circuit.try_run { 'ok' }
       circuit.try_run { raise 'fail' }
       expect(circuit.status.closed?).to be(true)
@@ -212,7 +212,7 @@ RSpec.context :circuits do
 
     it 'raises unwrapped error if error is excluded' do
       test_error = Class.new(StandardError)
-      circuit = Faulty::Circuit.new('test', **options.merge(exclude: test_error))
+      circuit = Faulty::Circuit.new('test', **options, exclude: test_error)
       expect do
         circuit.run { raise test_error }
       end.to raise_error(test_error)
@@ -220,14 +220,14 @@ RSpec.context :circuits do
 
     it 'raises unwrapped error if error is not included' do
       test_error = Class.new(StandardError)
-      circuit = Faulty::Circuit.new('test', **options.merge(errors: test_error))
+      circuit = Faulty::Circuit.new('test', **options, errors: test_error)
       expect do
         circuit.run { raise StandardError, 'test' }
       end.to raise_error(StandardError, 'test')
     end
 
     it 'raises all unwrapped errors if errors option is empty' do
-      circuit = Faulty::Circuit.new('test', **options.merge(errors: []))
+      circuit = Faulty::Circuit.new('test', **options, errors: [])
       expect do
         circuit.run { raise 'fail' }
       end.to raise_error(RuntimeError, 'fail')

--- a/spec/events/callback_listener_spec.rb
+++ b/spec/events/callback_listener_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Faulty::Events::CallbackListener do
   end
 
   it 'does nothing for unknown event' do
-    listener.handle(:fake_event, circuit: 'test')
+    expect { listener.handle(:fake_event, circuit: 'test') }.not_to raise_error
   end
 
   it 'allows event with no handlers' do
-    listener.handle(:circuit_opened, circuit: 'test')
+    expect { listener.handle(:circuit_opened, circuit: 'test') }.not_to raise_error
   end
 
   it 'calls multiple handlers' do
@@ -23,7 +23,7 @@ RSpec.describe Faulty::Events::CallbackListener do
     listener.circuit_opened { |payload| results << payload }
     listener.circuit_opened { |payload| results << payload }
     listener.handle(:circuit_opened, circuit: 'test')
-    expect(results).to match_array([{ circuit: 'test' }, { circuit: 'test' }])
+    expect(results).to contain_exactly({ circuit: 'test' }, { circuit: 'test' })
   end
 
   it 'can register listeners in initialize block' do

--- a/spec/events/log_listener_spec.rb
+++ b/spec/events/log_listener_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Faulty::Events::LogListener do
   subject(:listener) { described_class.new(logger) }
 
   let(:logger) do
-    logger = ::Logger.new(io)
+    logger = Logger.new(io)
     logger.level = :debug
     logger
   end

--- a/spec/patch/mysql2_spec.rb
+++ b/spec/patch/mysql2_spec.rb
@@ -18,11 +18,9 @@ RSpec.describe 'Faulty::Patch::Mysql2', if: defined?(Mysql2) do
   def trip_circuit
     client
     4.times do
-      begin
-        new_client(host: '127.0.0.1', port: 9999, faulty: { instance: faulty })
-      rescue Mysql2::Error
-        # Expect connection failure
-      end
+      new_client(host: '127.0.0.1', port: 9999, faulty: { instance: faulty })
+    rescue Mysql2::Error
+      # Expect connection failure
     end
   end
 

--- a/spec/patch/redis_spec.rb
+++ b/spec/patch/redis_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Faulty::Patch::Redis do
   let(:faulty) { Faulty.new(listeners: []) }
 
   let(:bad_url) { 'redis://127.0.0.1:9876' }
-  let(:bad_redis) { ::Redis.new(opts(url: bad_url, faulty: { instance: faulty })) }
-  let(:good_redis) { ::Redis.new(opts(faulty: { instance: faulty })) }
-  let(:bad_unpatched_redis) { ::Redis.new(opts(url: bad_url)) }
+  let(:bad_redis) { Redis.new(opts(url: bad_url, faulty: { instance: faulty })) }
+  let(:good_redis) { Redis.new(opts(faulty: { instance: faulty })) }
+  let(:bad_unpatched_redis) { Redis.new(opts(url: bad_url)) }
   let(:bad_redis_unpatched_errors) do
-    ::Redis.new(opts(url: bad_url, faulty: { instance: faulty, patch_errors: false }))
+    Redis.new(opts(url: bad_url, faulty: { instance: faulty, patch_errors: false }))
   end
   let(:timeout) { 1 }
 
@@ -38,7 +38,7 @@ RSpec.describe Faulty::Patch::Redis do
 
   it 'captures connection error' do
     expect { connect(bad_redis) }.to raise_error do |error|
-      expect(error).to be_a(::Redis::BaseConnectionError)
+      expect(error).to be_a(Redis::BaseConnectionError)
       if Redis::VERSION.to_f >= 5
         expect(faulty_cause(error)).to be_a(Faulty::Patch::Redis::CircuitError)
       else
@@ -49,13 +49,13 @@ RSpec.describe Faulty::Patch::Redis do
   end
 
   it 'does not capture connection error if no circuit' do
-    expect { connect(bad_unpatched_redis) }.to raise_error(::Redis::BaseConnectionError)
+    expect { connect(bad_unpatched_redis) }.to raise_error(Redis::BaseConnectionError)
     expect(faulty.circuit('redis').status.failure_rate).to eq(0)
   end
 
   it 'captures connection error during command' do
     expect { bad_redis.ping }.to raise_error do |error|
-      expect(error).to be_a(::Redis::BaseConnectionError)
+      expect(error).to be_a(Redis::BaseConnectionError)
       expect(faulty_cause(error)).to be_a(Faulty::Patch::Redis::CircuitError)
     end
     expect(faulty.circuit('redis').status.failure_rate).to eq(1)
@@ -75,13 +75,11 @@ RSpec.describe Faulty::Patch::Redis do
     let(:busy_thread) do
       event = Concurrent::Event.new
       thread = Thread.new do
-        begin
-          event.wait(1)
-          # This thread will block here until killed
-          ::Redis.new(timeout: 10).eval("while true do\n end")
-        rescue Redis::CommandError
-          # Ok when script is killed
-        end
+        event.wait(1)
+        # This thread will block here until killed
+        Redis.new(timeout: 10).eval("while true do\n end")
+      rescue Redis::CommandError
+        # Ok when script is killed
       end
       # Wait for the new thread to be scheduled
       # and for the Redis command to be executed
@@ -98,7 +96,7 @@ RSpec.describe Faulty::Patch::Redis do
 
     after do
       begin
-        ::Redis.new(timeout: 10).call(%w[SCRIPT KILL])
+        Redis.new(timeout: 10).call(%w[SCRIPT KILL])
       rescue Redis::CommandError
         # Ok if no script is running
       end
@@ -107,7 +105,7 @@ RSpec.describe Faulty::Patch::Redis do
 
     it 'captures busy command error' do
       expect { good_redis.ping }.to raise_error do |error|
-        expect(error).to be_a(::Redis::BaseConnectionError)
+        expect(error).to be_a(Redis::BaseConnectionError)
         expect(faulty_cause(error)).to be_a(Faulty::Patch::Redis::BusyError)
         expect(faulty_cause(error).message).to match(
           /BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,11 +25,9 @@ require 'json'
 require 'connection_pool'
 
 begin
-  # We don't test Mysql2 on Ruby 2.3 since that would require
-  # installing an old EOL version of OpenSSL
-  require 'faulty/patch/mysql2' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4')
+  require 'faulty/patch/mysql2'
 rescue LoadError
-  # Ok if mysql2 isn't available
+  # Ok if mysql2 isn't available (e.g. JRuby/TruffleRuby)
 end
 
 require_relative 'support/concurrency'

--- a/spec/storage/redis_spec.rb
+++ b/spec/storage/redis_spec.rb
@@ -4,7 +4,7 @@ require 'connection_pool'
 require 'redis'
 
 RSpec.describe Faulty::Storage::Redis do
-  subject(:storage) { described_class.new(**options.merge(client: client)) }
+  subject(:storage) { described_class.new(**options, client: client) }
 
   let(:options) { {} }
   let(:client) { Redis.new(timeout: 1) }
@@ -40,7 +40,7 @@ RSpec.describe Faulty::Storage::Redis do
       expect(storage.history(circuit).size).to eq(1)
     end
 
-    it 'opens the circuit once when called concurrently', concurrency: true do
+    it 'opens the circuit once when called concurrently', :concurrency do
       concurrent_warmup do
         # Do something small just to get a connection from the pool
         storage.unlock(circuit)
@@ -124,7 +124,7 @@ RSpec.describe Faulty::Storage::Redis do
     before { hide_const('ConnectionPool') }
 
     it 'can construct a storage' do
-      storage
+      expect { storage }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Why

Master's last green CI run was July 2025. Since then, GitHub Actions runner upgrades and dependency drift made the workflow effectively unrunnable: OpenSearch service containers fail to boot, `simplecov-cobertura 2.1.0` produces a coverage report the new REXML parser rejects (so even passing test runs exit 1), and the Rubocop pin is two years stale. This blocked any PR (e.g. #70) from getting a clean signal.

The codebase has been functionally stable for a while, so rather than patching individual pins this branch modernizes the floor and ships the result as **0.12.0**. Runtime behavior is unchanged from `0.11.0` — the version bump reflects the support-policy and toolchain breaking changes only (per the 0.x convention of bumping the minor on breaking changes). Upgrading should be a drop-in replacement on any supported Ruby.

## What's in here

### 0.12.0 release prep

- `lib/faulty/version.rb` -> `0.12.0`.
- `CHANGELOG.md` gets a `[0.12.0]` section with Breaking / Changed / Removed buckets calling out the Ruby support drop.
- `faulty.gemspec` declares `required_ruby_version = '>= 3.1'`, so older Rubies refuse to install the gem.

### Runtime

- Drop support for Ruby < 3.1 (2.3 - 3.0 are EOL upstream).
- Lazy-`require 'logger'` in `LogListener#initialize` only when the fallback `::Logger.new($stderr)` branch is actually taken. Ruby 3.5 extracts `logger` from default gems, and the eager require crashed boot with `NameError` on stock 3.3+. Pre-existing bug, surfaced once transitive requires went away.

### CI matrix (`.github/workflows/ci.yml`)

- Ruby: `3.1, 3.2, 3.3, 3.4, jruby-head, truffleruby-head`.
- OpenSearch: `2.19.5` default + a `3.0.0` row. Pass `DISABLE_INSTALL_DEMO_CONFIG=true` to the service container so OpenSearch 2.12+ doesn't refuse to boot waiting on `OPENSEARCH_INITIAL_ADMIN_PASSWORD` for a security demo we're immediately disabling anyway.
- Elasticsearch: keep the `7.17.x` back-compat row. Image is bumped to `elasticsearch:7.17.28` (the JDK in the original `7.17.0` image NPEs against the cgroupv2 setup on current runners); gem floor is `elasticsearch ~> 7.17.11`, the latest 7.17 client. Drop the Elasticsearch 8.15.0 row entirely — the Faulty patch still references `Elasticsearch::Transport::Transport::Error`, and ES 8+ moved transport into the `elastic-transport` gem under `Elastic::Transport`. ES 8 support is a separate refactor, tracked as follow-up.
- Redis: default redis gem `5`, keep one `4` row, drop `3`.
- Actions: `checkout@v4`, `codecov-action@v5`. Toolchain jobs (rubocop / yard / check_version / release) move to Ruby `3.4`.

### Gemfile

- Replace deprecated `:mingw` / `:x64_mingw` platform symbols with the unified `:windows` symbol Bundler now expects (the old form prints a `[DEPRECATED]` line at every `bundle install`).
- Pin `rubocop ~> 1.84` (was `1.32`; the old version emitted a wall of deprecation warnings against `rubocop-ast 1.49`).
- Pin `rubocop-rspec ~> 3.9`.
- Pin `simplecov-cobertura ~> 3.1` (the 2.x XML-without-root-element bug is fixed in 3.x).
- Pin `opensearch-ruby ~> 3.4` (was 2.1).
- Add `logger` for dev/test/benchmark only.

### Rubocop config

- `TargetRubyVersion: 3.1`, `NewCops: enable`, migrate `require:` to `plugins:`.
- Drop the now-extracted `RSpec/Capybara/*`, `RSpec/Rails/*`, `RSpec/FactoryBot/*` entries; replace `RSpec/FilePath` with the new `RSpec/SpecFilePath{Format,Suffix}` knobs.
- Scope-exclude three new cops that misfire on intentional patterns: `Naming/PredicateMethod` (`lib/faulty/storage/**` - `open`/`close`/`reopen` are imperative interface methods that happen to return booleans; renaming would break `Storage::Interface`), `Style/OneClassPerFile` (`lib/faulty/patch/**` - monkey-patches reopen upstream constants), and `RSpec/IndexedLet` (`auto_wire_spec.rb` - numbered duplicate-backend fixtures read clearer than contrived names).
- Disable `Gemspec/DevelopmentDependencies` (the gemspec intentionally splits essential vs non-essential dev deps with the Gemfile).

### Autocorrects from `rubocop -A` (no behavior change)

- `&block` -> anonymous `&` forwarding.
- `begin/rescue/end` inside a method body -> method/block-level `rescue`.
- `::Redis` / `::Logger` -> `Redis` / `Logger` (no namespace collisions).
- `**hash.merge(k: v)` -> `hash, k: v`.
- `.select { |k,_v| %i[..].include?(k) }` -> `.slice(...)`.
- `add_runtime_dependency` -> `add_dependency`.

### Tiny spec touch-ups

- Wrap three "nothing raises" tests in `expect { ... }.not_to raise_error` so they actually assert behavior (and silence `RSpec/NoExpectationExample`).
- Drop the Ruby-2.3 mysql2 carve-out in `spec_helper.rb`.

## Test plan

- [x] `bundle exec rubocop` - 81 files, 0 offenses.
- [x] `bin/yardoc --fail-on-warning` - 87% documented, no warnings.
- [x] `bin/benchmark` runs cleanly on this branch. Two-run averages show the in-memory / log-listener paths land ~2 - 3% faster than master (consistent direction across all four CPU-bound rows, plausibly from `.slice` and anonymous-block forwarding); Redis paths are within run-to-run noise.
- [x] Full matrix green on push.

## Follow-up

- PR #70 ("Reserve half-open tests") still has a real `Metrics/AbcSize` offense in the new pipelined `Redis#status`. Easiest fix once this branch lands and #70 rebases on top: extract the futures-fetch into a small helper. Not in scope here.
- Elasticsearch 8.x client support. Requires reworking `lib/faulty/patch/elasticsearch.rb` to handle both the pre-8 `Elasticsearch::Transport` namespace and the 8.x `Elastic::Transport` namespace (in the split-out `elastic-transport` gem). Tracked separately so it doesn't gate this release.
