### PR TITLE
Wrap Cache::Default in AutoWire fault-tolerance proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 -------------------
 
+[0.13.1] - 2026-05-29
+---------------------
+
+### Fixed
+
+* `Cache::AutoWire.wrap` now applies `CircuitProxy` and `FaultTolerantProxy`
+  to `Cache::Default` when the resolved backend is not fault tolerant (e.g.
+  `Rails.cache`). Previously a `nil` cache short-circuited the wrapping and
+  could leave the auto-wired cache non-fault-tolerant. justinhoward
+
 [0.13.0] - 2026-05-13
 ---------------------
 

--- a/lib/faulty/cache/auto_wire.rb
+++ b/lib/faulty/cache/auto_wire.rb
@@ -29,7 +29,10 @@ class Faulty
       class << self
         # Wrap a cache backend with sensible defaults
         #
-        # If the cache is `nil`, create a new {Default}.
+        # If the cache is `nil`, create a new {Default}. Since {Default} may
+        # resolve to a non-fault-tolerant backend (e.g. `Rails.cache`), the
+        # result is passed back through {wrap} so it still receives the
+        # {CircuitProxy} and {FaultTolerantProxy} wrappers when needed.
         #
         # If the backend is not fault tolerant, wrap it in {CircuitProxy} and
         # {FaultTolerantProxy}.
@@ -40,7 +43,7 @@ class Faulty
         def wrap(cache, **options, &)
           options = Options.new(options, &)
           if cache.nil?
-            Cache::Default.new
+            wrap(Cache::Default.new, **options.to_h)
           elsif cache.fault_tolerant?
             cache
           else

--- a/lib/faulty/version.rb
+++ b/lib/faulty/version.rb
@@ -3,6 +3,6 @@
 class Faulty
   # The current Faulty version
   def self.version
-    Gem::Version.new('0.13.0')
+    Gem::Version.new('0.13.1')
   end
 end

--- a/spec/cache/auto_wire_spec.rb
+++ b/spec/cache/auto_wire_spec.rb
@@ -15,6 +15,40 @@ RSpec.describe Faulty::Cache::AutoWire do
     end
   end
 
+  context 'with a nil backend' do
+    let(:backend) { nil }
+
+    it 'is fault tolerant' do
+      expect(auto_wire).to be_fault_tolerant
+    end
+
+    context 'when Default resolves to a non-fault-tolerant backend' do
+      before do
+        allow(Faulty::Cache::Default).to receive(:new).and_return(
+          Faulty::Cache::Rails.new(nil, fault_tolerant: false)
+        )
+      end
+
+      it 'wraps Default in FaultTolerantProxy and CircuitProxy' do
+        expect(auto_wire).to be_a(Faulty::Cache::FaultTolerantProxy)
+
+        circuit_proxy = auto_wire.instance_variable_get(:@cache)
+        expect(circuit_proxy).to be_a(Faulty::Cache::CircuitProxy)
+        expect(circuit_proxy.options.circuit).to eq(circuit)
+      end
+    end
+
+    context 'when Default resolves to a fault-tolerant backend' do
+      let(:default) { Faulty::Cache::Null.new }
+
+      before { allow(Faulty::Cache::Default).to receive(:new).and_return(default) }
+
+      it 'returns Default unwrapped' do
+        expect(auto_wire).to eq(default)
+      end
+    end
+  end
+
   context 'with a non-fault-tolerant backend' do
     let(:backend) { Faulty::Cache::Rails.new(nil, fault_tolerant: false) }
 


### PR DESCRIPTION
Previously, passing `cache: nil` (or relying on the default) returned `Cache::Default.new` unwrapped. Because `Default` can resolve to a non-fault-tolerant `Rails.cache`, this bypassed the `CircuitProxy` and `FaultTolerantProxy` wrappers that the rest of `Cache::AutoWire` guarantees, leaving the auto-wired cache potentially non-fault-tolerant.

Recurse through `wrap` with the constructed `Default` so it is treated like any other supplied backend: fault-tolerant resolutions (Null, ActiveSupport MemoryStore) pass through unchanged, while a non-fault-tolerant `Rails.cache` now gets the standard proxy stack.

Add specs covering both `Default` resolutions to pin the behavior.